### PR TITLE
Angle: Use googlesource link

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1905,7 +1905,7 @@ if [[ $mpv != "n" ]] && pc_exists libavcodec libavformat libswscale libavfilter;
 
     do_pacman_remove angleproject-git
     _check=(EGL/egl.h)
-    if mpv_enabled egl-angle && do_vcs "https://github.com/google/angle.git"; then
+    if mpv_enabled egl-angle && do_vcs "https://chromium.googlesource.com/angle/angle"; then
         do_simple_print "${orange}mpv will need libGLESv2.dll and libEGL.dll to execute"'!'
         do_simple_print "You can find these in your browser's installation directory, usually."
         do_uninstall include/{EGL,GLES{2,3},GLSLANG,KHR,platform} angle_gl.h \


### PR DESCRIPTION
Closes #1345

``` bash
time do_vcs https://github.com/google/angle.git angle-github
...
real    0m44.089s
user    0m12.337s
sys     0m13.566s

On another computer
┌ angle-github git  .................................. [Recently updated]

real    1m5.574s
user    0m12.402s
sys     0m6.068s
```

``` bash
time do_vcs https://chromium.googlesource.com/angle/angle angle-google
...
real    0m34.467s
user    0m14.244s
sys     0m14.144s

On another computer
┌ angle-google git  .................................. [Recently updated]

real    0m36.132s
user    0m14.120s
sys     0m6.098s
```

_Originally posted by @1480c1 in https://github.com/m-ab-s/media-autobuild_suite/issues/1345#issuecomment-521672890_

Seems to be faster(?)