### PR TITLE
Add libsvtav1 to ffmpeg options full

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -94,7 +94,7 @@ libaom libopenmpt version3
 :: options also available with the suite
 set ffmpeg_options_full=chromaprint decklink frei0r libbs2b libcaca ^
 libcdio libfdk-aac libflite libfribidi libgme libgsm libilbc libsvthevc libkvazaar ^
-libmodplug librtmp librubberband libssh libtesseract libxavs libzmq ^
+libmodplug librtmp librubberband libssh libtesseract libxavs libzmq libsvtav1 ^
 libzvbi openal libvmaf libcodec2 libsrt ladspa #vapoursynth #liblensfun #librav1e
 
 :: options also available with the suite that add shared dependencies

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -95,7 +95,7 @@ libaom libopenmpt version3
 set ffmpeg_options_full=chromaprint decklink frei0r libbs2b libcaca ^
 libcdio libfdk-aac libflite libfribidi libgme libgsm libilbc libsvthevc libsvtav1 ^
 libkvazaar libmodplug librtmp librubberband libssh libtesseract libxavs libzmq ^
-libzvbi openal libvmaf libcodec2 libsrt ladspa #vapoursynth #liblensfun #librav1e ^
+libzvbi openal libvmaf libcodec2 libsrt ladspa #vapoursynth #liblensfun #librav1e
 
 :: options also available with the suite that add shared dependencies
 set ffmpeg_options_full_shared=opencl opengl cuda-nvcc libnpp libopenh264

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -94,8 +94,9 @@ libaom libopenmpt version3
 :: options also available with the suite
 set ffmpeg_options_full=chromaprint decklink frei0r libbs2b libcaca ^
 libcdio libfdk-aac libflite libfribidi libgme libgsm libilbc libsvthevc libkvazaar ^
-libmodplug librtmp librubberband libssh libtesseract libxavs libzmq libsvtav1 ^
-libzvbi openal libvmaf libcodec2 libsrt ladspa #vapoursynth #liblensfun #librav1e
+libmodplug librtmp librubberband libssh libtesseract libxavs libzmq ^
+libzvbi openal libvmaf libcodec2 libsrt ladspa #vapoursynth #liblensfun #librav1e ^
+#libsvtav1
 
 :: options also available with the suite that add shared dependencies
 set ffmpeg_options_full_shared=opencl opengl cuda-nvcc libnpp libopenh264

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -93,10 +93,9 @@ libaom libopenmpt version3
 
 :: options also available with the suite
 set ffmpeg_options_full=chromaprint decklink frei0r libbs2b libcaca ^
-libcdio libfdk-aac libflite libfribidi libgme libgsm libilbc libsvthevc libkvazaar ^
-libmodplug librtmp librubberband libssh libtesseract libxavs libzmq ^
+libcdio libfdk-aac libflite libfribidi libgme libgsm libilbc libsvthevc libsvtav1 ^
+libkvazaar libmodplug librtmp librubberband libssh libtesseract libxavs libzmq ^
 libzvbi openal libvmaf libcodec2 libsrt ladspa #vapoursynth #liblensfun #librav1e ^
-#libsvtav1
 
 :: options also available with the suite that add shared dependencies
 set ffmpeg_options_full_shared=opencl opengl cuda-nvcc libnpp libopenh264


### PR DESCRIPTION
Adds `libsvtav1` to `ffmpeg_options_full` to add support for the SVT-AV1 encoder in ffmpeg.

Even if it seems to be broken right now, at least for me...