### PR TITLE
rav1e: Add flags to do_rust to address rav1e issues on Windows on CPU's with AVX2

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -971,7 +971,7 @@ if { [[ $rav1e = y ]] || enabled librav1e; } &&
 
     # standalone binary
     if [[ $rav1e = y || $standalone = y ]]; then
-        do_rust
+        do_rust --no-default-features --features=binaries
         do_install "target/$CARCH-pc-windows-gnu/release/rav1e.exe" bin-video/
     fi
 

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1957,7 +1957,9 @@ do_rust() {
     extra_script pre rust
     log "build" "$RUSTUP_HOME/bin/cargo.exe" build --release \
         --target="$CARCH"-pc-windows-gnu \
-        --jobs="$cpuCount" "$@"
+        --jobs="$cpuCount" "$@" \
+		--no-default-features \
+		--features=binaries
     extra_script post rust
 }
 

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1957,9 +1957,7 @@ do_rust() {
     extra_script pre rust
     log "build" "$RUSTUP_HOME/bin/cargo.exe" build --release \
         --target="$CARCH"-pc-windows-gnu \
-        --jobs="$cpuCount" "$@" \
-		--no-default-features \
-		--features=binaries
+        --jobs="$cpuCount" "$@"
     extra_script post rust
 }
 


### PR DESCRIPTION
Recently, there's an issue with rav1e when using it on CPU's with AVX2.

This PR adds some flags that fixes the issue, as suggested on this issue that I also opened over there: https://github.com/xiph/rav1e/issues/1618