### PR TITLE
do_patch & do_wget: Rework to always check if local=remote

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -438,7 +438,7 @@ real_extract() {
 }
 
 do_extract() {
-    local nocd="${nocd:-}"
+    local nocd="${nocd:-false}"
     local archive="$1" dirName="$2"
     # accepted: zip, 7z, tar, tar.gz, tar.bz2 and tar.xz
     [[ -z $dirName ]] && dirName=$(guess_dirname "$archive")
@@ -451,13 +451,13 @@ do_extract() {
             rm -rf "$dirName"
         fi
     elif [[ -d $dirName ]]; then
-        [[ $nocd ]] || cd_safe "$dirName"
+        $nocd || cd_safe "$dirName"
         return 0
     elif ! expr "$archive" : '.\+\(tar\(\.\(gz\|bz2\|xz\)\)\?\|7z\|zip\)$' > /dev/null; then
         return 0
     fi
     log "extract" real_extract "$archive" "$dirName"
-    [[ $nocd ]] || cd_safe "$dirName"
+    $nocd || cd_safe "$dirName"
 }
 
 do_wget_sf() {


### PR DESCRIPTION
Fixes #1369 

Line 360 `if ! check_hash "$archive" "$hash"; then` was always skipping curl checks (If modified etc) so old patches were never updated

Use mktemp to create a temp file to reside in memory and compare with diff

Changed do_patch's default return code to 1 and only succeed if patch or git am actually worked