### PR TITLE
do_configure: Move prefix to default

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1925,7 +1925,7 @@ if [[ $mplayer = "y" ]] &&
     grep_or_sed windows libmpcodecs/ad_spdif.c '/#include "mp_msg.h/ a\#include <windows.h>'
 
     _notrequired="true"
-    do_configure --prefix="$LOCALDESTDIR" --bindir="$LOCALDESTDIR"/bin-video --cc=gcc \
+    do_configure --bindir="$LOCALDESTDIR"/bin-video --cc=gcc \
     --extra-cflags='-DPTW32_STATIC_LIB -O3 -std=gnu99 -DMODPLUG_STATIC' \
     --extra-libs='-llzma -liconv -lws2_32 -lpthread -lwinpthread -lpng -lwinmm' \
     --extra-ldflags='-Wl,--allow-multiple-definition' --enable-{static,runtime-cpudetection} \

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1519,7 +1519,7 @@ if enabled libxvid && [[ $standalone = y ]] && ! { files_exist "${_check[@]}" &&
     do_pacman_remove xvidcore
     do_uninstall "${_check[@]}"
     cd_safe build/generic
-    do_configure --prefix="$LOCALDESTDIR" --{build,host}="$MINGW_CHOST"
+    do_configure
     do_make
     do_install ../../src/xvid.h include/
     do_install '=build/xvidcore.a' libxvidcore.a

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1846,12 +1846,10 @@ if [[ $ffmpeg != "no" ]]; then
             do_uninstall bin-video/ffmpegSHARED "${_uninstall[@]}"
             [[ -f config.mak ]] && log "distclean" make distclean
             create_build_dir shared
-            extra_script pre configure
-            CFLAGS="${ffmpeg_cflags:-$CFLAGS}" \
+            config_path=.. CFLAGS="${ffmpeg_cflags:-$CFLAGS}" \
             LDFLAGS+=" -L$LOCALDESTDIR/lib -L$MINGW_PREFIX/lib" \
-                log configure ../configure \
+                do_configure \
                 --disable-static --enable-shared "${FFMPEG_OPTS_SHARED[@]}"
-            extra_script post configure
             # cosmetics
             sed -ri "s/ ?--($sedflags)=(\S+[^\" ]|'[^']+')//g" config.h
             do_make && do_makeinstall

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1231,7 +1231,7 @@ if [[ $ffmpeg != "no" ]] && enabled_any frei0r ladspa; then
         do_uninstall "${_check[@]}"
         [[ -f config.mak ]] && log clean make distclean
         sed -i 's|__declspec(dllexport)||g' dlfcn.h
-        do_configure --prefix="$LOCALDESTDIR" --disable-shared
+        do_configure --disable-shared
         do_make && do_makeinstall
         do_checkIfExist
     fi

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1873,12 +1873,10 @@ if [[ $ffmpeg != "no" ]]; then
             fi
             do_uninstall bin-video/ff{mpeg,play,probe}.exe{,.debug} "${_uninstall[@]}"
             create_build_dir static
-            extra_script pre configure
-            CFLAGS="${ffmpeg_cflags:-$CFLAGS}" \
+            config_path=.. CFLAGS="${ffmpeg_cflags:-$CFLAGS}" \
             LDFLAGS+=" -L$LOCALDESTDIR/lib -L$MINGW_PREFIX/lib" \
-                log configure ../configure --prefix="$LOCALDESTDIR" \
+                do_configure \
                 --bindir="$LOCALDESTDIR/bin-video" "${FFMPEG_OPTS[@]}"
-            extra_script post configure
             # cosmetics
             sed -ri "s/ ?--($sedflags)=(\S+[^\" ]|'[^']+')//g" config.h
             do_make && do_makeinstall

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -832,7 +832,7 @@ if enabled libflite && do_vcs "https://github.com/kubo/flite.git"; then
         libflite_cmu_us_{awb,kal,kal16,rms,slt}.a \
         libflite_{cmulex,usenglish,cmu_time_awb}.a "${_check[@]}" include/flite
     log clean make clean
-    do_configure --prefix="$LOCALDESTDIR" --bindir="$LOCALDESTDIR"/bin-audio --disable-shared \
+    do_configure --bindir="$LOCALDESTDIR"/bin-audio --disable-shared \
         --with-audio=none
     do_make && do_makeinstall
     do_checkIfExist

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1141,8 +1141,7 @@ elif { [[ $avs2 = y ]] || { [[ $ffmpeg != "no" ]] && enabled libxavs2; }; } &&
     cd_safe build/linux
     [[ -f "config.mak" ]] && log "distclean" make distclean
     do_uninstall all "${_check[@]}"
-    do_configure --host="$MINGW_CHOST" --prefix="$LOCALDESTDIR" \
-        --bindir="$LOCALDESTDIR"/bin-video --enable-static --enable-strip
+    do_configure --bindir="$LOCALDESTDIR"/bin-video --enable-static --enable-strip
     do_makeinstall
     do_checkIfExist
 fi

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1155,8 +1155,7 @@ elif { [[ $avs2 = y ]] || { [[ $ffmpeg != "no" ]] && enabled libdavs2; }; } &&
     cd_safe build/linux
     [[ -f "config.mak" ]] && log "distclean" make distclean
     do_uninstall all "${_check[@]}"
-    do_configure --host="$MINGW_CHOST" --prefix="$LOCALDESTDIR" \
-        --bindir="$LOCALDESTDIR"/bin-video --enable-strip
+    do_configure --bindir="$LOCALDESTDIR"/bin-video --enable-strip
     do_makeinstall
     do_checkIfExist
 fi

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1124,7 +1124,7 @@ if [[ $ffmpeg != "no" ]] && enabled libxavs && do_pkgConfig "xavs = 0.1." "0.1" 
     [[ -f "libxavs.a" ]] && log "distclean" make distclean
     do_uninstall "${_check[@]}"
     sed -i 's|"NUL"|"/dev/null"|g' configure
-    do_configure --host="$MINGW_CHOST" --prefix="$LOCALDESTDIR"
+    do_configure
     do_make libxavs.a
     for _file in xavs.h libxavs.a xavs.pc; do do_install "$_file"; done
     do_checkIfExist

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1183,12 +1183,12 @@ if [[ $mediainfo = "y" ]]; then
 
     _check=(bin-video/mediainfo.exe)
     _deps=(libmediainfo.a)
-    if do_vcs "https://github.com/MediaArea/MediaInfo" mediainfo; then
+    if do_vcs "https://github.com/MediaArea/MediaInfo.git" mediainfo; then
         cd_safe Project/GNU/CLI
         do_autogen
         do_uninstall "${_check[@]}"
         [[ -f Makefile ]] && log distclean make distclean
-        do_configure --build="$MINGW_CHOST" --disable-shared --bindir="$LOCALDESTDIR/bin-video" \
+        do_configure --disable-shared --bindir="$LOCALDESTDIR/bin-video" \
             --enable-staticlibs
         do_makeinstall
         do_checkIfExist

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2248,7 +2248,7 @@ if [[ $cyanrip = y ]]; then
                 fi
             )
             create_build_dir cyan
-            log configure ../configure "${FFMPEG_BASE_OPTS[@]}" \
+            config_path=.. do_configure "${FFMPEG_BASE_OPTS[@]}" \
                 --prefix="$LOCALDESTDIR/opt/cyanffmpeg" \
                 --disable-{programs,devices,filters,decoders,hwaccels,encoders,muxers} \
                 --disable-{debug,protocols,demuxers,parsers,doc,swscale,postproc,network} \

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1333,24 +1333,20 @@ if [[ $x264 != no ]]; then
                 mapfile -t audio_codecs < <(
                     sed -n '/audio codecs/,/external libraries/p' ../libavcodec/allcodecs.c |
                     sed -n 's/^[^#]*extern.* *ff_\([^ ]*\)_decoder;/\1/p')
-                extra_script pre configure
-                LDFLAGS+=" -L$MINGW_PREFIX/lib" \
-                    log configure ../configure "${FFMPEG_BASE_OPTS[@]}" \
+                config_path=.. LDFLAGS+=" -L$MINGW_PREFIX/lib" \
+                    do_configure "${FFMPEG_BASE_OPTS[@]}" \
                     --prefix="$LOCALDESTDIR/opt/lightffmpeg" \
                     --disable-{programs,devices,filters,encoders,muxers,debug,sdl2,network,protocols,doc} \
                     --enable-protocol=file,pipe \
                     --disable-decoder="$(IFS=, ; echo "${audio_codecs[*]}")" --enable-gpl \
                     --disable-bsf=aac_adtstoasc,text2movsub,noise,dca_core,mov2textsub,mp3_header_decompress \
                     --disable-autodetect --enable-{lzma,bzlib,zlib}
-                extra_script post configure
                 unset audio_codecs
             else
-                extra_script pre configure
-                LDFLAGS+=" -L$MINGW_PREFIX/lib" \
-                    log configure ../configure "${FFMPEG_BASE_OPTS[@]}" \
+                config_path=.. LDFLAGS+=" -L$MINGW_PREFIX/lib" \
+                    do_configure "${FFMPEG_BASE_OPTS[@]}" \
                     --prefix="$LOCALDESTDIR/opt/lightffmpeg" \
                     --disable-{programs,devices,filters,encoders,muxers,debug,sdl2,doc} --enable-gpl
-                    extra_script post configure
             fi
             do_makeinstall
             files_exist "${_check[@]}" && touch "build_successful${bits}_light"

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1421,7 +1421,7 @@ do_separate_conf() {
         config_path=".."
         create_build_dir
     fi
-    do_configure --{build,host,target}="$MINGW_CHOST" --prefix="$LOCALDESTDIR" --disable-shared --enable-static "$bindir" "$@"
+    do_configure --disable-shared --enable-static "$bindir" "$@"
 }
 
 do_separate_confmakeinstall() {
@@ -1435,7 +1435,7 @@ do_configure() {
     extra_script pre configure
     [[ -f "$(get_first_subdir)/do_not_reconfigure" ]] &&
         return
-    log "configure" ${config_path:-.}/configure "$@"
+    log "configure" ${config_path:-.}/configure --prefix="$LOCALDESTDIR" "$@"
     extra_script post configure
 }
 


### PR DESCRIPTION
Move prefix option from separateconf to do_configure.

Removed the build,host,target options since those _should_ be auto detected (but some configure scripts don't accept them)

Doesn't seem to break anything yet