### PR TITLE
Empty array FFMPEG_OPTS before filling it

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -775,6 +775,7 @@ do_getFFmpegConfig() {
         fi
     fi
 
+    FFMPEG_OPTS=()
     for opt in "${FFMPEG_BASE_OPTS[@]}" "${FFMPEG_DEFAULT_OPTS[@]}"; do
         [[ -n $opt ]] && FFMPEG_OPTS+=("$opt")
     done


### PR DESCRIPTION
<!--
Description

(Optional) Fixes #[issueNumber]
--->
When compiling the suite for both 32bit and 64 bit, the options from the 32 bit compile are mixed with those from the 64bit compile.
This is because when the suite is starting to compile for 64bit, the array containing the options is still filled with the options from the 32bit compile and the options for 64bit are just added on top.

This change will make the array empty before filling it with the options for 64bit to resolve this.

For MPV there is already a similar line MPV_OPTS=() in the code.
