### PR TITLE
Pat357check gnutls version online

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -775,6 +775,7 @@ do_getFFmpegConfig() {
         fi
     fi
 
+    FFMPEG_OPTS=()
     for opt in "${FFMPEG_BASE_OPTS[@]}" "${FFMPEG_DEFAULT_OPTS[@]}"; do
         [[ -n $opt ]] && FFMPEG_OPTS+=("$opt")
     done


### PR DESCRIPTION
<!--
Description

(Optional) Fixes #[issueNumber]
--->
gnutls : check version online & trigger rebuild on update

Current code does not trigger a rebuild when the version is updated ; after updating the suite, one has to do a force rebuild to get the current version.