### PR TITLE
webp: remove enable-experimental

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -471,7 +471,7 @@ _check=(libwebp{,mux}.{{,l}a,pc})
 if [[ $ffmpeg != "no" || $standalone = y ]] && enabled libwebp &&
     do_vcs "https://chromium.googlesource.com/webm/libwebp"; then
     if [[ $standalone = y ]]; then
-        extracommands=(--enable-{experimental,libwebp{demux,decoder,extras}}
+        extracommands=(--enable-libwebp{demux,decoder,extras}
             "LIBS=$($PKG_CONFIG --libs libpng libtiff-4)")
     else
         extracommands=()


### PR DESCRIPTION
It seems that this is no longer a valid option.

Relevant commit: https://github.com/msys2/MINGW-packages/commit/b502c1c4e9866ef71e6e2e43c91c9af503b4563e

Upstream commit: https://github.com/webmproject/libwebp/commit/f4dd92565e1d31a5dba40976a6084ddd025d3ca6