### PR TITLE
Helper: Add get_signature, check_signature, and do_jq 

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -2013,6 +2013,14 @@ create_cmake_toolchain() {
         printf '%s\n' "${toolchain_file[@]}" > "$LOCALDESTDIR"/etc/toolchain.cmake
 }
 
+get_signature() {
+    # get_signature 96865171 0F3BE490
+    # adds keys to gpg keychain for verifying
+    for keyserver in keys.openpgp.org pool.sks-keyservers.net keyserver.ubuntu.com pgp.mit.edu; do
+        gpg --keyserver "$keyserver" --receive-keys "$@" && break
+    done > /dev/null 2>&1
+}
+
 grep_or_sed() {
     local grep_re="$1"
     local grep_file="$2"

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -2067,6 +2067,24 @@ check_signature() {
     esac
 }
 
+do_jq() {
+    local jq_file="$jq_file" output_raw_string=true
+    # Detect if in pipe, useful for curling github api
+    if [[ ! -t 0 ]]; then
+        jq_file=/dev/stdin
+    elif [[ -f $1 ]]; then
+        jq_file="$1" && shift
+    fi
+    for a in "$@"; do
+        grep -q -- ^- <<< "$a" && output_raw_string=false
+    done
+    if $output_raw_string; then
+        jq -r "$*" < "$jq_file"
+    else
+        jq "$@" < "$jq_file"
+    fi
+}
+
 grep_or_sed() {
     local grep_re="$1"
     local grep_file="$2"

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1607,6 +1607,8 @@ rem ------------------------------------------------------------------
 if %build32%==yes call :writeProfile 32
 if %build64%==yes call :writeProfile 64
 
+findstr hkps://keys.openpgp.org "%instdir%\%msys2%\home\%USERNAME%\.gnupg\gpg.conf" || echo keyserver hkps://keys.openpgp.org >> "%instdir%\%msys2%\home\%USERNAME%\.gnupg\gpg.conf"
+
 rem loginProfile
 if exist %instdir%\%msys2%\etc\profile.pacnew ^
     move /y %instdir%\%msys2%\etc\profile.pacnew %instdir%\%msys2%\etc\profile


### PR DESCRIPTION
Add functions helpful for getting signatures for gpg and checking if a file is correct using a sig or asc file.

I might be able to add a check if the file starts properly, but that is already handled by gpg erroring out with non-zero

Split off from https://github.com/m-ab-s/media-autobuild_suite/pull/1221