### PR TITLE
ffmpeg: Enables librav1e in ffmpeg

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1849,13 +1849,6 @@ if [[ $ffmpeg != "no" ]]; then
         enabled vapoursynth &&
             do_patch "https://0x0.st/zp4W.txt vapoursynth_alt.patch" am
 
-        # librav1e
-        if enabled librav1e; then
-            # do_patch "https://patchwork.ffmpeg.org/patch/13874/mbox/" am ||
-            do_removeOption "--enable-librav1e"
-            do_removeOption FFMPEG_OPTS_SHARED "--enable-librav1e"
-        fi
-
         if [[ ${#FFMPEG_OPTS[@]} -gt 35 ]]; then
             # remove redundant -L and -l flags from extralibs
             do_patch "https://0x0.st/zLsN.txt" am

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -116,7 +116,7 @@ libaom libopenmpt version3
 set ffmpeg_options_full=chromaprint decklink frei0r libbs2b libcaca ^
 libcdio libfdk-aac libflite libfribidi libgme libgsm libilbc libsvthevc libsvtav1 ^
 libkvazaar libmodplug librtmp librubberband libssh libtesseract libxavs libzmq ^
-libzvbi openal libvmaf libcodec2 libsrt ladspa #vapoursynth #liblensfun #librav1e
+libzvbi openal libvmaf libcodec2 libsrt ladspa #vapoursynth #liblensfun librav1e
 
 :: options also available with the suite that add shared dependencies
 set ffmpeg_options_full_shared=opencl opengl cuda-nvcc libnpp libopenh264


### PR DESCRIPTION
ffmpeg merged support for librav1e. I removed some conditions for librav1e and ran the suite. Ffmpeg now compiles and allows the use of librav1e. It also runs fine.