### PR TITLE
codec2: Remove check for c2sim.exe

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -754,8 +754,8 @@ if [[ $ffmpeg != "no" ]] && enabled libsoxr; then
 fi
 
 _check=(libcodec2.a codec2.pc codec2/codec2.h)
-if [[ $ffmpeg != "no" ]] && enabled libcodec2 && do_pkgConfig "codec2 = 0.8"; then
-    [[ $standalone = y ]] && _check+=(bin-audio/c2{enc,dec,sim}.exe)
+if [[ $ffmpeg != "no" ]] && enabled libcodec2; then
+    [[ $standalone = y ]] && _check+=(bin-audio/c2{enc,dec}.exe)
     if do_vcs "https://github.com/drowe67/codec2.git"; then
         do_uninstall all include/codec2 "${_check[@]}"
         sed -i 's|if(WIN32)|if(FALSE)|g' CMakeLists.txt
@@ -767,7 +767,7 @@ if [[ $ffmpeg != "no" ]] && enabled libcodec2 && do_pkgConfig "codec2 = 0.8"; th
         do_cmakeinstall -D{UNITTEST,INSTALL_EXAMPLES}=off \
             -DCMAKE_INSTALL_BINDIR="$(pwd)/build-$bits/_bin"
         if [[ $standalone = y ]]; then
-            do_install _bin/c2{enc,dec,sim}.exe bin-audio/
+            do_install _bin/c2{enc,dec}.exe bin-audio/
         fi
         do_checkIfExist
     fi


### PR DESCRIPTION
codec2 git source compiles but does not produce the c2sim.exe executable, making it fail at this step. This PR removes the check and also removes the pkgconfig since we are compiling the master branch now.