### PR TITLE
msys2-base.tar.xz cleanup once it's working

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1607,6 +1607,7 @@ if %msys2%==msys32 (
     echo.-------------------------------------------------------------------------------
     call %instdir%\%msys2%\autorebase.bat
 )
+del "%build%\msys2-base.tar.xz" 2>nul
 
 rem ------------------------------------------------------------------
 rem write config profiles:


### PR DESCRIPTION
I noticed the file stuck around so I figured the best time to clean it up is after the second rebase. It definitely shouldn't be needed anymore after that.