### PR TITLE
ffmpeg+libvmaf: Replace default hard-coded model path

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1875,6 +1875,10 @@ if [[ $ffmpeg != "no" ]]; then
                 }
         fi
 
+        # Replace default hard-coded model path with generated one based on where it's installed converted for ifstream to find
+        grep_and_sed '/usr/local/share/model/vmaf_v0.6.1.pkl' libavfilter/vf_libvmaf.c \
+            "s;/usr/local/share/model/vmaf_v0.6.1.pkl;$(cygpath -m "$LOCALDESTDIR/share/model/vmaf_v0.6.1.pkl");g"
+
         _patches="$(git rev-list origin/master.. --count)"
         [[ $_patches -gt 0 ]] &&
             do_addOption "--extra-version=g$(git rev-parse --short origin/master)+$_patches"


### PR DESCRIPTION
@wiiaboo, do you think there's a better way to do this?

Works after recompiling ffmpeg

Caused by https://github.com/Netflix/vmaf/issues/424


If there's nothing, I will merge this around tomorrow