### PR TITLE
create_diagnostic: Add path to diagnostic.txt

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1939,7 +1939,7 @@ clean_suite() {
 create_diagnostic() {
     local cmd cmds=("uname -a" "pacman -Qe" "pacman -Qd")
     local _env envs=(MINGW_{PACKAGE_PREFIX,CHOST,PREFIX} MSYSTEM CPATH
-        LIBRARY_PATH {LD,C,CPP,CXX}FLAGS)
+        LIBRARY_PATH {LD,C,CPP,CXX}FLAGS PATH)
     do_print_progress "  Creating diagnostics file"
     git -C /trunk rev-parse --is-inside-work-tree > /dev/null 2>&1 &&
         cmds+=("git -C /trunk log -1 --pretty=%h")


### PR DESCRIPTION
@wiiaboo, do you think this would be a good idea? I feel that knowing the contents of `$PATH` and especially the ordering during a compilation can be helpful when trying to diagnose an issue, but I'm not sure if this could be considered too much since that's mainly outside of variables set/directly used by the suite.