### PR TITLE
Removed bash.ps1 from being downloaded since the file has been removed.

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1299,7 +1299,7 @@ rem ------------------------------------------------------------------
 rem download and install basic msys2 system:
 rem ------------------------------------------------------------------
 cd %build%
-set scripts=media-suite_compile.sh media-suite_helper.sh media-suite_update.sh bash.ps1
+set scripts=media-suite_compile.sh media-suite_helper.sh media-suite_update.sh
 for %%s in (%scripts%) do (
     if not exist "%build%\%%s" (
         powershell -Command (New-Object System.Net.WebClient^).DownloadFile('"https://github.com/m-ab-s/media-autobuild_suite/raw/master/build/%%s"', '"%%s"' ^)


### PR DESCRIPTION
The `bash.ps1` file was removed in the commit da663b5926e9562aa159b169a404df71bc32232e, but the script was still attempting to download this file.

Fixes #1541 
