### PR TITLE
Zab-suite.sh: Source helper.sh

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1601,6 +1601,9 @@ findstr /C:"profile2.local" %instdir%\%msys2%\etc\profile.d\Zab-suite.sh >nul 2>
     echo.elif [[ -z "$MSYSTEM" ^|^| "$MSYSTEM" = MINGW32 ]]; then
     echo.   source /local32/etc/profile2.local
     echo.fi
+    echo.if [[ -f /build/media-suite_helper.sh ]]; then
+    echo.   source /build/media-suite_helper.sh
+    echo.fi
 )>%instdir%\%msys2%\etc\profile.d\Zab-suite.sh
 
 rem compileLocals


### PR DESCRIPTION
Helps me not have to write
```bash
source /build/media-suite_helper.sh
```
every single time I ask somebody to run a command in mintty

Is there a particular reason this was not done before?