### PR TITLE
libaom: Move libaom to light build from zeranoe

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For information about the compiler environment see the wiki, there you also have
         - cuda-llvm (built-in)
         - cuvid (built-in)
         - ffnvcodec (git)
+        - libaom (git)
         - libdav1d (git)
         - libmp3lame (mingw)
         - libopus (mingw)
@@ -49,7 +50,6 @@ For information about the compiler environment see the wiki, there you also have
             - mbedtls (mingw)
                 - preferred to gnutls if GPLv3 license is chosen
             - gnutls (latest release)
-        - libaom (git)
         - libass (git)
             - by default with DirectWrite backend
             - if --enable-fontconfig, fontconfig backend included

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -103,14 +103,14 @@ iconv lzma nvenc schannel zlib sdl2 ffnvcodec nvdec cuda-llvm
 
 :: common external libs
 set ffmpeg_options_basic=gmp libmp3lame libopus libvorbis libvpx libx264 libx265 ^
-libdav1d --disable-debug
+libdav1d libaom --disable-debug
 
 :: options used in zeranoe builds and not present above
 set ffmpeg_options_zeranoe=fontconfig gnutls libass libbluray libfreetype ^
 libmfx libmysofa libopencore-amrnb libopencore-amrwb libopenjpeg libsnappy ^
 libsoxr libspeex libtheora libtwolame libvidstab libvo-amrwbenc libwavpack ^
 libwebp libxml2 libzimg libshine gpl openssl libtls avisynth mbedtls libxvid ^
-libaom libopenmpt version3
+libopenmpt version3
 
 :: options also available with the suite
 set ffmpeg_options_full=chromaprint decklink frei0r libbs2b libcaca ^


### PR DESCRIPTION
Since we already have libdav1d for decoding av1, it would be good to also have a library to encode av1.

@wiiaboo any comments?