### PR TITLE
VLC patches to allow compilation with the medialibrary master branch

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2590,7 +2590,8 @@ if [[ $vlc == y ]]; then
         # msys2's patches
         # Issues due to conflicting `vlc_module_name` between libvlc and libvlccore when linking vlc-static.exe and undefines.
         # having gpg-error after GCRYPT_LIBS causes some issues, and since it's already included in GCRYPT_LIBS
-        do_patch "https://gist.githubusercontent.com/1480c1/8c50a0867aa1afceac064d2162120dde/raw/vlc-mabs.patch" am
+        do_patch "https://gist.githubusercontent.com/moisespr123/2369978dc603ed1e67bdf7aba7304416/raw/f83d6cd9171765ee87140bfc1555529aa029f240/vlc-corrected-patch" am
+        do_patch "https://gist.githubusercontent.com/moisespr123/70e16f70f5d016c3d0f0dacbf97526f0/raw/ad70ecd5db0b6349cb47c85932ce5e408cbb7004/medialib-patch"
 
         do_autoreconf
         # All of the disabled are because of multiple issues both on the installed libs and on vlc's side.

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2590,8 +2590,8 @@ if [[ $vlc == y ]]; then
         # msys2's patches
         # Issues due to conflicting `vlc_module_name` between libvlc and libvlccore when linking vlc-static.exe and undefines.
         # having gpg-error after GCRYPT_LIBS causes some issues, and since it's already included in GCRYPT_LIBS
-        do_patch "https://gist.githubusercontent.com/moisespr123/2369978dc603ed1e67bdf7aba7304416/raw/f83d6cd9171765ee87140bfc1555529aa029f240/vlc-corrected-patch" am
-        do_patch "https://gist.githubusercontent.com/moisespr123/70e16f70f5d016c3d0f0dacbf97526f0/raw/ad70ecd5db0b6349cb47c85932ce5e408cbb7004/medialib-patch"
+        do_patch "https://gist.githubusercontent.com/moisespr123/2369978dc603ed1e67bdf7aba7304416/raw/vlc-corrected-patch" am
+        do_patch "https://gist.githubusercontent.com/moisespr123/70e16f70f5d016c3d0f0dacbf97526f0/raw/medialib-patch"
 
         do_autoreconf
         # All of the disabled are because of multiple issues both on the installed libs and on vlc's side.


### PR DESCRIPTION
Added the following 2 patches:

* [vlc-corrected-patch](https://gist.github.com/moisespr123/2369978dc603ed1e67bdf7aba7304416): This is a rebase of the original patch by @1480c1 to make it apply to VLC's master branch.
* [medialib-patch](https://gist.github.com/moisespr123/70e16f70f5d016c3d0f0dacbf97526f0): This allows us to compile VLC using medialibrary master branch.

Note that VLC is still buggy. It will work, but will present an exception upon launching it. Press ignore and it will work. It has issues playing back videos (some doesn't open the video window. Other have distorted colors), but I'm sure this is not related to the above patches and is something else with the codecs.

Fixes #1583
