### PR TITLE
Mention libsvtvp9 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ For information about the compiler environment see the wiki, there you also have
         - libssh (broken)
         - libsvtav1 (git) (using non-upstream patch)
         - libsvthevc (git) (using non-upstream patch)
+        - libsvtvp9 (git) (using non-upstream patch)
         - libtesseract (git)
         - libvmaf (git)
         - libxavs (svn snapshot)


### PR DESCRIPTION
I noticed #1619 forgot to mention this in the documentation, so here it is.