### PR TITLE
Allow --enable-librav1e

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1903,11 +1903,6 @@ if [[ $ffmpeg != no ]]; then
         enabled vapoursynth &&
             do_patch "https://0x0.st/zp4W.txt vapoursynth_alt.patch" am
 
-        # librav1e
-        if enabled librav1e; then
-            do_removeOption FFMPEG_OPTS_SHARED "--enable-librav1e"
-        fi
-
         if [[ ${#FFMPEG_OPTS[@]} -gt 35 ]]; then
             # remove redundant -L and -l flags from extralibs
             do_patch "https://0x0.st/zLsN.txt" am


### PR DESCRIPTION
As far as I can tell, this is no longer necessary. Built and tested it, it works just fine.