### PR TITLE
ffmpeg: support libglslang and vulkan

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ For information about the compiler environment see the wiki, there you also have
             - needs non-free license if not LGPL
         - libflite (git)
         - libfribidi (latest release)
+        - libglslang (git)
         - libgme (git snapshot)
         - libgsm (mingw-w64)
         - libilbc (git snapshot)
@@ -119,6 +120,7 @@ For information about the compiler environment see the wiki, there you also have
         - opencl (from system)
         - opengl (from system)
         - vapoursynth (R50)
+        - vulkan (git)
 
 - other tools
     - aom (git)

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1783,6 +1783,42 @@ if [[ $ffmpeg != no ]] && enabled avisynth &&
     do_checkIfExist
 fi
 
+_check=(libvulkan.a vulkan.pc vulkan/vulkan.h d3d{kmthk,ukmdt}.h)
+if { { [[ $ffmpeg != no ]] && enabled vulkan; } || ! mpv_disabled vulkan; } &&
+    do_vcs "https://github.com/KhronosGroup/Vulkan-Loader.git" vulkan-loader; then
+    _DeadSix27=https://raw.githubusercontent.com/DeadSix27/python_cross_compile_script/master
+    _shinchiro=https://raw.githubusercontent.com/shinchiro/mpv-winbuild-cmake/master
+    do_uninstall "${_check[@]}"
+    do_patch "$_shinchiro/packages/vulkan-0001-cross-compile-static-linking-hacks.patch" am
+    create_build_dir
+    log dependencies /usr/bin/python3 ../scripts/update_deps.py --no-build
+    cd_safe Vulkan-Headers
+        do_print_progress "Installing Vulkan-Headers"
+        do_uninstall include/vulkan
+        do_cmakeinstall
+        do_wget -c -r -q "$_DeadSix27/additional_headers/d3dkmthk.h"
+        do_wget -c -r -q "$_DeadSix27/additional_headers/d3dukmdt.h"
+        do_install d3d{kmthk,ukmdt}.h include/
+    cd_safe "$(get_first_subdir -f)"
+    do_print_progress "Building Vulkan-Loader"
+    do_cmakeinstall -DBUILD_TESTS=OFF -DCMAKE_SYSTEM_NAME=Windows -DUSE_CCACHE=OFF \
+    -DCMAKE_ASM_COMPILER="$(command -v nasm.exe)" -DVULKAN_HEADERS_INSTALL_DIR="$LOCALDESTDIR" \
+    -DENABLE_STATIC_LOADER=ON -DUNIX=OFF
+    do_checkIfExist
+    unset _DeadSix27 _shinchiro
+fi
+
+_check=(lib{glslang,OSDependent,HLSL,OGLCompiler,SPVRemapper}.a
+        libSPIRV{,-Tools{,-opt,-link,-reduce}}.a)
+if [[ $ffmpeg != no ]] && enabled libglslang &&
+    do_vcs "https://github.com/KhronosGroup/glslang.git"; then
+    do_uninstall "${_check[@]}"
+    log dependencies /usr/bin/python ./update_glslang_sources.py
+    do_patch "https://raw.githubusercontent.com/shinchiro/mpv-winbuild-cmake/master/packages/glslang-0001-fix-gcc-10.1-error.patch" am
+    do_cmakeinstall -DUNIX=OFF
+    do_checkIfExist
+fi
+
 enabled openssl && hide_libressl
 if [[ $ffmpeg != no ]]; then
     enabled libgsm && do_pacman_install gsm
@@ -2097,31 +2133,6 @@ if [[ $mpv != n ]] && pc_exists libavcodec libavformat libswscale libavfilter; t
         do_install build/host/lib/*.a lib/
         cmake -E copy_directory include "$LOCALDESTDIR/include"
         do_checkIfExist
-    fi
-
-    _check=(libvulkan.a vulkan.pc vulkan/vulkan.h d3d{kmthk,ukmdt}.h)
-    if ! mpv_disabled vulkan &&
-        do_vcs "https://github.com/KhronosGroup/Vulkan-Loader.git" vulkan-loader; then
-        _DeadSix27=https://raw.githubusercontent.com/DeadSix27/python_cross_compile_script/master
-        _shinchiro=https://raw.githubusercontent.com/shinchiro/mpv-winbuild-cmake/master
-        do_uninstall "${_check[@]}"
-        do_patch "$_shinchiro/packages/vulkan-0001-cross-compile-static-linking-hacks.patch" am
-        create_build_dir
-        log dependencies /usr/bin/python3 ../scripts/update_deps.py --no-build
-        cd_safe Vulkan-Headers
-            do_print_progress "Installing Vulkan-Headers"
-            do_uninstall include/vulkan
-            do_cmakeinstall
-            do_wget -c -r -q "$_DeadSix27/additional_headers/d3dkmthk.h"
-            do_wget -c -r -q "$_DeadSix27/additional_headers/d3dukmdt.h"
-            do_install d3d{kmthk,ukmdt}.h include/
-        cd_safe "$(get_first_subdir -f)"
-        do_print_progress "Building Vulkan-Loader"
-        do_cmakeinstall -DBUILD_TESTS=no -DCMAKE_SYSTEM_NAME=Windows -DUSE_CCACHE=OFF \
-        -DCMAKE_ASM_COMPILER="$(command -v nasm.exe)" -DVULKAN_HEADERS_INSTALL_DIR="$LOCALDESTDIR" \
-        -DENABLE_STATIC_LOADER=ON -DUNIX=off
-        do_checkIfExist
-        unset _DeadSix27
     fi
 
     _check=(shaderc/shaderc.h libshaderc_combined.a)

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -127,7 +127,8 @@ libopenmpt version3
 set ffmpeg_options_full=chromaprint decklink frei0r libbs2b libcaca ^
 libcdio libfdk-aac libflite libfribidi libgme libgsm libilbc libsvthevc libsvtav1 ^
 #libsvtvp9 libkvazaar libmodplug librtmp librubberband #libssh libtesseract libxavs ^
-libzmq libzvbi openal libvmaf libcodec2 libsrt ladspa librav1e #vapoursynth #liblensfun
+libzmq libzvbi openal libvmaf libcodec2 libsrt ladspa librav1e #vapoursynth #liblensfun ^
+libglslang vulkan
 
 :: options also available with the suite that add shared dependencies
 set ffmpeg_options_full_shared=opencl opengl cuda-nvcc libnpp libopenh264


### PR DESCRIPTION
Description
vulkan can be used by both ffmpeg and mpv, so move up its compilation to above ffmpeg.

(Optional)
Might fix #1565