### PR TITLE
Add SVT-VP9 temporary workaround

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1915,6 +1915,16 @@ if [[ $ffmpeg != no ]]; then
         _deps=(lib{aom,tesseract,vmaf,x265,vpx}.a)
     if do_vcs "https://git.ffmpeg.org/ffmpeg.git"; then
 
+        # ((TEMPORARY SVT-VP9 MEASURES))
+        # Reasons for this codeblock = https://github.com/m-ab-s/media-autobuild_suite/pull/1619#issuecomment-616206347
+        if enabled libsvtvp9; then
+            enabled libxvid && do_removeOption --enable-libxvid &&
+                do_print_progress "Until an upstream fix is issued, compiling with libsvtvp9 must disable libxvid."
+            enabled libsvtav1 && do_removeOption --enable-libsvtav1 &&
+                do_print_progress "Until an upstream fix is issued, compiling with libsvtvp9 must disable libsvtav1."
+        fi
+        # (/(TEMPORARY SVT-VP9 MEASURES))
+
         # ((TEMPORARY SVT-AV1 MEASURES))
         # Reasons for this codeblock = https://github.com/OpenVisualCloud/SVT-AV1/issues/567
         if enabled libsvtav1; then

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1915,22 +1915,15 @@ if [[ $ffmpeg != no ]]; then
         _deps=(lib{aom,tesseract,vmaf,x265,vpx}.a)
     if do_vcs "https://git.ffmpeg.org/ffmpeg.git"; then
 
-        # See issue https://github.com/OpenVisualCloud/SVT-AV1/issues/567 for the reasons behind the follow codeblock:
-        # start of SVT-AV1 temporary measures
+        # ((TEMPORARY SVT-AV1 MEASURES))
+        # Reasons for this codeblock = https://github.com/OpenVisualCloud/SVT-AV1/issues/567
         if enabled libsvtav1; then
-            if enabled libaom && enabled libopencore-amrwb; then
-                do_print_progress "Until SVT-AV1 issues a fix, libaom & libopencore-amrwb must be disabled while libsvtav1 is enabled."
-                do_removeOption --enable-libaom
-                do_removeOption --enable-libopencore-amrwb
-            elif enabled libaom; then
-                do_print_progress "Until SVT-AV1 issues a fix, libaom must be disabled while libsvtav1 is enabled."
-                do_removeOption --enable-libaom
-            elif enabled libopencore-amrwb; then
-                do_print_progress "Until SVT-AV1 issues a fix, libopencore-amrwb must be disabled while libsvtav1 is enabled."
-                do_removeOption --enable-libopencore-amrwb
-            fi
+            enabled libaom && do_removeOption --enable-libaom &&
+                do_print_progress "Until an upstream fix is issued, compiling with libsvtvp9 must disable libaom."
+            enabled libopencore-amrwb && do_removeOption --enable-libopencore-amrwb &&
+                do_print_progress "Until an upstream fix is issued, compiling with libsvtvp9 must disable libopencore-amrwb."
         fi
-        # end of SVT-AV1 temporary measures
+        # (/(TEMPORARY SVT-AV1 MEASURES))
 
         do_changeFFmpegConfig "$license"
         [[ -f ffmpeg_extra.sh ]] && source ffmpeg_extra.sh


### PR DESCRIPTION
https://github.com/m-ab-s/media-autobuild_suite/pull/1619#issuecomment-616206347 taught me that ffmpeg cannot be compiled with SVT-VP9 while the SVT-AV1 and XVid options are enabled (and I did test to make sure XVid did indeed conflict). There doesn't seem to be anything to reference or handle this conflict other than these few comments, so I made a quick codeblock to do so.

I also revised the SVT-AV1 codeblock in the process. Much cleaner code seems a bit more important than trying to keep the log message down to a single line.