### PR TITLE
SVT_VP9: No longer disables xvid/svtav1 for ffmpeg

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1914,16 +1914,6 @@ if [[ $ffmpeg != no ]]; then
         _deps=(lib{aom,tesseract,vmaf,x265,vpx}.a)
     if do_vcs "https://git.ffmpeg.org/ffmpeg.git"; then
 
-        # ((TEMPORARY SVT-VP9 MEASURES))
-        # Reasons for this codeblock = https://github.com/m-ab-s/media-autobuild_suite/pull/1619#issuecomment-616206347
-        if enabled libsvtvp9; then
-            enabled libxvid && do_removeOption --enable-libxvid &&
-                do_print_progress "Until an upstream fix is issued, libxvid must be disabled when compiling with libsvtvp9."
-            enabled libsvtav1 && do_removeOption --enable-libsvtav1 &&
-                do_print_progress "Until an upstream fix is issued, libsvtav1 must be disabled when compiling with libsvtvp9."
-        fi
-        # (/(TEMPORARY SVT-VP9 MEASURES))
-
         # ((TEMPORARY SVT-AV1 MEASURES))
         # Reasons for this codeblock = https://github.com/OpenVisualCloud/SVT-AV1/issues/567
         if enabled libsvtav1; then


### PR DESCRIPTION
Did some test compiles today using the patch described here until it's corrected upstream: https://github.com/m-ab-s/media-autobuild_suite/issues/1725#issuecomment-652664267

I can confirm that SVT_VP9 no longer needs to disable libxvid or libsvtav1. I compiled both shared and static builds successfully.

_(Unfortunately, libsvtav1 still needs to disable libaom and libopencore-amrwb)_