### PR TITLE
do_vcs: drop mercurial and svn

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Building everything from scratch takes about ~3 hours depending on what is enabl
 
 Check [forcing-recompilations](./doc/forcing-recompilations.md) to check how you can force a rebuild of all libs/binaries.
 
-To save a bit of space you can delete, after compiling, all source folders (except the folders with a "-git", "-svn" or "-hg" on end) in /build. There's an option in the .bat for the script to remove these folders automatically.
+To save a bit of space you can delete, after compiling, all source folders (except the folders with a "-git" or "-svn" on end) in /build. There's an option in the .bat for the script to remove these folders automatically.
 
 Have fun!
 
@@ -256,7 +256,7 @@ If there's some error during compilation follow these steps:
 
 `media-autobuild_suite.bat`
 
-- This file sets up the msys2 system and the compiler environment. For normal use you only have to start this file. Every time you start this batch file it runs through the process, but after the first time it only checks some variables and run updates to the MinGW environment. After that it only compiles the tools that get updates from svn/git/hg.
+- This file sets up the msys2 system and the compiler environment. For normal use you only have to start this file. Every time you start this batch file it runs through the process, but after the first time it only checks some variables and run updates to the MinGW environment. After that it only compiles the tools that get updates from svn/git.
 
 `/build/media-autobuild_suite.ini`
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For information about the compiler environment see the wiki, there you also have
         - libmodplug (mingw-w64)
         - libopencore-amr(nb/wb) (mingw-w64)
         - libopenjpeg2 (mingw-w64)
-        - libopenmpt (svn from beta release)
+        - libopenmpt (git tag)
         - libsnappy (mingw-w64)
         - libsoxr (git)
         - libspeex (mingw-w64)
@@ -112,7 +112,7 @@ For information about the compiler environment see the wiki, there you also have
         - libsvtvp9 (git) (using non-upstream patch)
         - libtesseract (git)
         - libvmaf (git)
-        - libxavs (svn snapshot)
+        - libxavs (git)
         - libxavs2 (git)
         - libzmq (mingw-w64)
         - libzvbi (0.2.35)
@@ -256,7 +256,7 @@ If there's some error during compilation follow these steps:
 
 `media-autobuild_suite.bat`
 
-- This file sets up the msys2 system and the compiler environment. For normal use you only have to start this file. Every time you start this batch file it runs through the process, but after the first time it only checks some variables and run updates to the MinGW environment. After that it only compiles the tools that get updates from svn/git.
+- This file sets up the msys2 system and the compiler environment. For normal use you only have to start this file. Every time you start this batch file it runs through the process, but after the first time it only checks some variables and run updates to the MinGW environment. After that it only compiles the tools that get updates from git.
 
 `/build/media-autobuild_suite.ini`
 

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2049,7 +2049,7 @@ if [[ $ffmpeg != no ]]; then
 fi
 
 # static do_vcs just for svn
-do_svn() {
+check_mplayer_updates() {
     cd_safe "$LOCALBUILDDIR"
     if [[ ! -d mplayer-svn/.svn ]]; then
         rm -rf mplayer-svn
@@ -2111,7 +2111,7 @@ do_svn() {
 }
 
 _check=(bin-video/m{player,encoder}.exe)
-if [[ $mplayer = y ]] && do_svn; then
+if [[ $mplayer = y ]] && check_mplayer_updates; then
     [[ $license != nonfree || $faac == n ]] && faac_opts=(--disable-faac)
     do_uninstall "${_check[@]}"
     [[ -f config.mak ]] && log "distclean" make distclean

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1556,9 +1556,6 @@ if [[ ! $x265 = n ]] && do_vcs "https://bitbucket.org/multicoreware/x265_git.git
     [[ $bits = 32bit ]] && assembly=-DENABLE_ASSEMBLY=OFF
     [[ $x265 = d ]] && xpsupport=-DWINXP_SUPPORT=ON
 
-    # Fix hg.bat using python2 still
-    grep_and_sed python2 /usr/bin/hg.bat 's/python2/python3/'
-
     build_x265() {
         create_build_dir
         local build_root=$PWD
@@ -1569,7 +1566,7 @@ if [[ ! $x265 = n ]] && do_vcs "https://bitbucket.org/multicoreware/x265_git.git
         extra_script pre cmake
         log "cmake" cmake "$(get_first_subdir -f)/source" -G Ninja \
         -DCMAKE_INSTALL_PREFIX="$LOCALDESTDIR" -DBIN_INSTALL_DIR="$LOCALDESTDIR/bin-video" \
-        -DENABLE_SHARED=OFF -DENABLE_CLI=OFF -DHIGH_BIT_DEPTH=ON -DHG_EXECUTABLE=/usr/bin/hg.bat \
+        -DENABLE_SHARED=OFF -DENABLE_CLI=OFF -DHIGH_BIT_DEPTH=ON \
         -DENABLE_HDR10_PLUS=ON $xpsupport -DCMAKE_CXX_COMPILER="$LOCALDESTDIR/bin/g++.bat" \
         -DCMAKE_TOOLCHAIN_FILE="$LOCALDESTDIR/etc/toolchain.cmake" "$@"
         extra_script post cmake

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -450,11 +450,11 @@ do_extract() {
     # accepted: zip, 7z, tar, tar.gz, tar.bz2 and tar.xz
     [[ -z $dirName ]] && dirName=$(guess_dirname "$archive")
     if [[ $dirName != "." && -d $dirName ]]; then
-        if [[ $build32 == "yes" ]] &&
-            [[ ! -f "$dirName"/build_successful32bit || -n $flavor && ! -f "$dirName/build_successful32bit_${flavor}" ]]; then
+        if [[ $build32 == "yes" &&
+            ! -f "$dirName/build_successful32bit${flavor:+_$flavor}" ]]; then
             rm -rf "$dirName"
-        elif [[ $build64 == "yes" ]] &&
-            [[ ! -f "$dirName"/build_successful64bit || -n $flavor && ! -f "$dirName/build_successful64bit_${flavor}" ]]; then
+        elif [[ $build64 == "yes" &&
+            ! -f "$dirName/build_successful64bit${flavor:+_$flavor}" ]]; then
             rm -rf "$dirName"
         fi
     elif [[ -d $dirName ]]; then

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -286,7 +286,7 @@ do_vcs() {
         } >> "$LOCALBUILDDIR"/newchangelog
         do_print_status "┌ $vcsFolder git" "$orange" "Updates found"
     elif [[ -f recently_updated ]] &&
-        [[ ! -f build_successful$bits || -n $flavor && ! -f build_successful${bits}_$flavor ]]; then
+        [[ ! -f build_successful$bits${flavor:+_$flavor} ]]; then
         do_print_status "┌ $vcsFolder git" "$orange" "Recently updated"
     elif [[ -n ${vcsCheck[*]} ]] && ! files_exist "${vcsCheck[@]}"; then
         do_print_status "┌ $vcsFolder git" "$orange" "Files missing"

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -37,6 +37,8 @@ else
 fi
 [[ -f media-suite_helper.sh ]] && source media-suite_helper.sh
 
+do_pacman_remove -m mercurial
+
 # --------------------------------------------------
 # update suite
 # --------------------------------------------------

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -42,6 +42,6 @@ To use these, you can either:
 
 Look at [updating.md](./updating.md) for when you want to update the suite or just rerun the batch script as it will automatically look for updates itself.
 
-If you want to rebuild the programs from scratch at any time due to an error or something else, delete the local[64|32] folder folder and remove any *-git, *-hg, and *-svn folders from the build folder. Finally rerun the batch script, it should redownload all of those folders and rebuild into a new local[64|32] folder.
+If you want to rebuild the programs from scratch at any time due to an error or something else, delete the local[64|32] folder folder and remove any \*-git and \*-svn folders from the build folder. Finally rerun the batch script, it should redownload all of those folders and rebuild into a new local[64|32] folder.
 
 If you want to rebuild the suite from scratch completely, in addition to deleting the folders specified above, also delete the msys[64|32] folder and rerun the script. It should at that point redownload and setup the msys2 system again.

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1186,7 +1186,7 @@ if %deleteSourceINI%==0 (
     echo. 1 = Yes [recommended]
     echo. 2 = No
     echo.
-    echo. This will save a bit of space for libraries not compiled from git/svn.
+    echo. This will save a bit of space for libraries not compiled from git.
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -102,7 +102,7 @@ set build=%instdir%\build
 if not exist %build% mkdir %build%
 
 set msyspackages=asciidoc autoconf automake-wrapper autogen base bison diffstat dos2unix filesystem help2man ^
-intltool libtool patch python xmlto make zip unzip git subversion wget p7zip mercurial man-db ^
+intltool libtool patch python xmlto make zip unzip git subversion wget p7zip man-db ^
 gperf winpty texinfo gyp-git doxygen autoconf-archive itstool ruby mintty flex
 
 set mingwpackages=cmake dlfcn libpng gcc nasm pcre tools-git yasm ninja pkg-config meson ccache jq ^
@@ -1186,7 +1186,7 @@ if %deleteSourceINI%==0 (
     echo. 1 = Yes [recommended]
     echo. 2 = No
     echo.
-    echo. This will save a bit of space for libraries not compiled from git/hg/svn.
+    echo. This will save a bit of space for libraries not compiled from git/svn.
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
@@ -1505,28 +1505,6 @@ if not defined TERM (
     set "TERM=xterm-256color"
 )
 
-rem hgsettings
-if not exist "%instdir%\msys64\home\%USERNAME%\.hgrc" (
-    echo.[ui]
-    echo.username = %USERNAME%
-    echo.verbose = True
-    echo.editor = vim
-    echo.
-    echo.[web]
-    echo.cacerts=/usr/ssl/cert.pem
-    echo.
-    echo.[extensions]
-    echo.color =
-    echo.
-    echo.[color]
-    echo.status.modified = magenta bold
-    echo.status.added = green bold
-    echo.status.removed = red bold
-    echo.status.deleted = cyan bold
-    echo.status.unknown = blue bold
-    echo.status.ignored = black bold
-)>"%instdir%\msys64\home\%USERNAME%\.hgrc"
-
 rem gitsettings
 if not exist "%instdir%\msys64\home\%USERNAME%\.gitconfig" (
     echo.[user]
@@ -1572,21 +1550,6 @@ if not exist %instdir%\msys64\usr\bin\make.exe (
 )
 
 for %%i in (%instdir%\msys64\usr\ssl\cert.pem) do if %%~zi==0 call :runBash cert.log update-ca-trust
-
-rem sethgBat
-if not exist %instdir%\msys64\usr\bin\hg.bat (
-    echo.@echo off
-    echo.
-    echo.setlocal
-    echo.set HG=^%%~f0
-    echo.
-    echo.set PYTHONHOME=
-    echo.set in=^%%*
-    echo.set out=^%%in: ^{= ^"^{^%%
-    echo.set out=^%%out:^} =^}^" ^%%
-    echo.
-    echo.^%%~dp0python2 ^%%~dp0hg ^%%out^%%
-)>%instdir%\msys64\usr\bin\hg.bat
 
 rem installmingw
 if exist "%instdir%\msys64\etc\pac-mingw.pk" del "%instdir%\msys64\etc\pac-mingw.pk"


### PR DESCRIPTION
Wanted to get someone else to also look at this code before I merge it just to make sure.

ideally, `do_vcs` will
```bash
if ! proper repo; then
    clone repo
fi
fetch updates, but not merge
get the merge-base of the current local repo and upstream
if not checked recently; then
    reset to upstream
fi

check if merge base != current hash and return new updates
rest of the logic stuff
```

for mplayer, I just put a static version of `do_vcs` with the unnecessary stuff removed, so as long as svn doesn't change or anything, it shouldn't need to be changed. I am considering just maybe moving the actual code into a subshell inside the if, but that also seems like it would cause a lot of ugliness.

maybe another time I might actually look a bit more at cleaning up the mplayer portion