### PR TITLE
Fix tesseract

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -548,7 +548,7 @@ if [[ $ffmpeg != no || $standalone = y ]] && enabled libtesseract; then
     fi
 
     _check=(libtesseract.{,l}a tesseract.pc)
-    if do_vcs "https://github.com/tesseract-ocr/tesseract.git"; then
+    if do_vcs "https://github.com/tesseract-ocr/tesseract.git#branch=4.1"; then
         do_pacman_install docbook-xsl libarchive pango asciidoc
         # Don't include curl in tesseract. We aren't mainly using the executable with links.
         # tesseract doesn't have a --disable-curl option or something so it's dumb.


### PR DESCRIPTION
Tesseract pre-release doesn't work when building

output when the problem appear :
20:14:02(B   Running git update for tesseract...
20:14:03(B ┌ tesseract git (B ............................ [Recently updated(B]
20:14:10(B ├(B Running autogen...
20:14:54(B ├(B Running configure...
20:16:49(B ├(B Running make...
Likely error (tail of the failed operation logfile):
  CXXLD    libtesseract_avx2.la
  CXXLD    libtesseract_fma.la
  CXXLD    libtesseract_sse.la
  CXXLD    libtesseract.la
  CXXLD    tesseract.exe
make[2]: *** No rule to make target 'src/training/tessopt.h', needed by 'all-am'.  Stop.
make[2]: Leaving directory '/build/tesseract-git/build-64bit'
make[1]: *** [Makefile:5577: all-recursive] Error 1
make[1]: Leaving directory '/build/tesseract-git/build-64bit'
make: *** [Makefile:2038: all] Error 2
make failed. Check C:/Users/Jonathan/Desktop/ba/build/tesseract-git/build-64bit/ab-suite.make.log(B
This is required for other packages, so this script will exit.(B
20:21:12(B   Creating diagnostics file...

<!--
Description

(Optional) Fixes #[issueNumber]
--->
