### PR TITLE
using correct name for VVC software

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -511,7 +511,7 @@ if %vvcINI%==0 (
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
     echo.
-    echo. Build Fraunhofer VVC? [H.265 successor enc/decoder]
+    echo. Build VVC Reference Software? [H.265 successor enc/decoder]
     echo. 1 = Yes
     echo. 2 = No
     echo.


### PR DESCRIPTION
- misleading  VVC software name (Fraunhofer VVC), which is not used in the build script
- build script is using the VVC Reference Software VTM (https://gitlab.com/m-ab-s/VVCSoftware_VTM.git) 
- if Fraunhofer VVC software should be used, VVenC/VVdeC have to be added as a build step
