### PR TITLE
Add additional VVC program suits into autobuild media

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ For information about the compiler environment see the wiki, there you also have
     - svt-av1 (git)
     - tesseract (git)
     - uvg266 (git)
+    - vvenc & vvdec (git)
     - vorbis-tools (git snapshot)
     - vpx (VP8 and VP9 8, 10 and 12 bit) (git)
     - vvc tools (git)

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1833,7 +1833,7 @@ _check=(bin-video/vvenc{,FF}.exe
 if [[ $bits = 64bit && $vvenc = y ]] &&
     do_vcs "https://github.com/fraunhoferhhi/vvenc.git" vvenc; then
     do_uninstall include/vvenc lib/cmake/vvenc "${_check[@]}"
-    do_cmakeinstall -DCMAKE_INSTALL_BINDIR="$LOCALDESTDIR"/bin-video/vvenc \
+    do_cmakeinstall video \
         -DBUILD_STATIC=on
     do_checkIfExist
 fi

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1843,7 +1843,7 @@ _check=(bin-video/vvdecapp.exe
     libvvdec.{a,pc}
     lib/cmake/vvdec/vvdecConfig.cmake)
 if [[ $bits = 64bit && $vvdec = y ]] &&
-    do_vcs "https://github.com/fraunhoferhhi/vvdec.git" vvdec; then
+    do_vcs "https://github.com/fraunhoferhhi/vvdec.git"; then
     do_uninstall bin-video/vvdec
     do_cmakeinstall -DCMAKE_INSTALL_BINDIR="$LOCALDESTDIR"/bin-video/vvdec \
         -DBUILD_STATIC=on

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1825,7 +1825,7 @@ if [[ $bits = 64bit && $uvg266 = y ]] &&
     do_checkIfExist
 fi
 
-_check=(bin-video/vvenc/vvenc{app,FFapp,interfacetest,libtest}.exe)
+_check=(bin-video/vvenc/vvenc{app,FFapp}.exe)
 if [[ $bits = 64bit && $vvenc = y ]] &&
     do_vcs "https://github.com/fraunhoferhhi/vvenc.git" vvenc; then
     do_uninstall bin-video/vvenc

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1825,7 +1825,7 @@ if [[ $bits = 64bit && $uvg266 = y ]] &&
     do_checkIfExist
 fi
 
-_check=(bin-video/vvenc{,FF}.exe
+_check=(bin-video/vvenc{,FF}app.exe
     vvenc/vvenc.h
     libvvenc.{a,pc}
     lib/cmake/vvenc/vvencConfig.cmake

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1831,7 +1831,7 @@ _check=(bin-video/vvenc{,FF}.exe
     lib/cmake/vvenc/vvencConfig.cmake
     libapputils.a)
 if [[ $bits = 64bit && $vvenc = y ]] &&
-    do_vcs "https://github.com/fraunhoferhhi/vvenc.git" vvenc; then
+    do_vcs "https://github.com/fraunhoferhhi/vvenc.git"; then
     do_uninstall include/vvenc lib/cmake/vvenc "${_check[@]}"
     do_cmakeinstall video \
         -DBUILD_STATIC=on

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1844,7 +1844,7 @@ _check=(bin-video/vvdecapp.exe
     lib/cmake/vvdec/vvdecConfig.cmake)
 if [[ $bits = 64bit && $vvdec = y ]] &&
     do_vcs "https://github.com/fraunhoferhhi/vvdec.git"; then
-    do_uninstall bin-video/vvdec
+    do_uninstall include/vvdec lib/cmake/vvdec "${_check[@]}"
     do_cmakeinstall -DCMAKE_INSTALL_BINDIR="$LOCALDESTDIR"/bin-video/vvdec \
         -DBUILD_STATIC=on
     do_checkIfExist

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1845,7 +1845,7 @@ _check=(bin-video/vvdecapp.exe
 if [[ $bits = 64bit && $vvdec = y ]] &&
     do_vcs "https://github.com/fraunhoferhhi/vvdec.git"; then
     do_uninstall include/vvdec lib/cmake/vvdec "${_check[@]}"
-    do_cmakeinstall -DCMAKE_INSTALL_BINDIR="$LOCALDESTDIR"/bin-video/vvdec \
+    do_cmakeinstall video \
         -DBUILD_STATIC=on
     do_checkIfExist
 fi

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -58,6 +58,8 @@ while true; do
     --jpegxl=* ) jpegxl=${1#*=} && shift ;;
     --vvc=* ) vvc=${1#*=} && shift ;;
     --uvg266=* ) uvg266=${1#*=} && shift ;;
+    --vvenc=* ) vvenc=${1#*=} && shift ;;
+    --vvdec=* ) vvdec=${1#*=} && shift ;;
     --jq=* ) jq=${1#*=} && shift ;;
     --jo=* ) jo=${1#*=} && shift ;;
     --dssim=* ) dssim=${1#*=} && shift ;;
@@ -1820,6 +1822,24 @@ if [[ $bits = 64bit && $uvg266 = y ]] &&
     do_vcs "https://github.com/ultravideo/uvg266.git"; then
     do_uninstall version.h "${_check[@]}"
     do_cmakeinstall video -DBUILD_TESTING=OFF
+    do_checkIfExist
+fi
+
+_check=(bin-video/vvenc/vvenc{app,FFapp,interfacetest,libtest}.exe)
+if [[ $bits = 64bit && $vvenc = y ]] &&
+    do_vcs "https://github.com/fraunhoferhhi/vvenc.git" vvenc; then
+    do_uninstall bin-video/vvenc
+    do_cmakeinstall -DCMAKE_INSTALL_BINDIR="$LOCALDESTDIR"/bin-video/vvenc \
+        -DBUILD_STATIC=on
+    do_checkIfExist
+fi
+
+_check=(bin-video/vvdec/vvdecapp.exe)
+if [[ $bits = 64bit && $vvdec = y ]] &&
+    do_vcs "https://github.com/fraunhoferhhi/vvdec.git" vvdec; then
+    do_uninstall bin-video/vvdec
+    do_cmakeinstall -DCMAKE_INSTALL_BINDIR="$LOCALDESTDIR"/bin-video/vvdec \
+        -DBUILD_STATIC=on
     do_checkIfExist
 fi
 

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1838,7 +1838,10 @@ if [[ $bits = 64bit && $vvenc = y ]] &&
     do_checkIfExist
 fi
 
-_check=(bin-video/vvdec/vvdecapp.exe)
+_check=(bin-video/vvdecapp.exe
+    vvdec/vvdec.h
+    libvvdec.{a,pc}
+    lib/cmake/vvdec/vvdecConfig.cmake)
 if [[ $bits = 64bit && $vvdec = y ]] &&
     do_vcs "https://github.com/fraunhoferhhi/vvdec.git" vvdec; then
     do_uninstall bin-video/vvdec

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1825,7 +1825,11 @@ if [[ $bits = 64bit && $uvg266 = y ]] &&
     do_checkIfExist
 fi
 
-_check=(bin-video/vvenc/vvenc{app,FFapp}.exe)
+_check=(bin-video/vvenc{,FF}.exe
+    vvenc/vvenc.h
+    libvvenc.{a,pc}
+    lib/cmake/vvenc/vvencConfig.cmake
+    libapputils.a)
 if [[ $bits = 64bit && $vvenc = y ]] &&
     do_vcs "https://github.com/fraunhoferhhi/vvenc.git" vvenc; then
     do_uninstall bin-video/vvenc

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1832,7 +1832,7 @@ _check=(bin-video/vvenc{,FF}.exe
     libapputils.a)
 if [[ $bits = 64bit && $vvenc = y ]] &&
     do_vcs "https://github.com/fraunhoferhhi/vvenc.git" vvenc; then
-    do_uninstall bin-video/vvenc
+    do_uninstall include/vvenc lib/cmake/vvenc "${_check[@]}"
     do_cmakeinstall -DCMAKE_INSTALL_BINDIR="$LOCALDESTDIR"/bin-video/vvenc \
         -DBUILD_STATIC=on
     do_checkIfExist

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -149,7 +149,7 @@ set iniOptions=arch license2 vpx2 x2643 x2652 other265 flac fdkaac mediainfo ^
 soxB ffmpegB2 ffmpegUpdate ffmpegChoice mp4box rtmpdump mplayer2 mpv cores deleteSource ^
 strip pack logging bmx standalone updateSuite aom faac exhale ffmbc curl cyanrip2 ^
 rav1e ripgrep dav1d libavif vvc uvg266 jq dssim avs2 timeStamp noMintty ccache ^
-svthevc svtav1 svtvp9 xvc jo vlc CC jpegxl autouploadlogs
+svthevc svtav1 svtvp9 xvc jo vlc CC jpegxl autouploadlogs vvenc vvdec
 
 set deleteIni=0
 set ini=%build%\media-autobuild_suite.ini
@@ -545,6 +545,46 @@ if %builduvg266%==1 set "uvg266=y"
 if %builduvg266%==2 set "uvg266=n"
 if %builduvg266% GTR 2 GOTO uvg266
 if %deleteINI%==1 echo.uvg266=^%builduvg266%>>%ini%
+
+:vvenc
+if %vvencINI%==0 (
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    echo.
+    echo. Build vvenc? [Fraunhoferhhi Versatile Video Encoder]
+    echo. 1 = Yes
+    echo. 2 = No
+    echo.
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    set /P buildvvenc="Build vvenc: "
+) else set buildvvenc=%vvencINI%
+
+if "%buildvvenc%"=="" GOTO vvenc
+if %buildvvenc%==1 set "vvenc=y"
+if %buildvvenc%==2 set "vvenc=n"
+if %buildvvenc% GTR 2 GOTO vvenc
+if %deleteINI%==1 echo.vvenc=^%buildvvenc%>>%ini%
+
+:vvdec
+if %vvdecINI%==0 (
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    echo.
+    echo. Build vvdec? [Fraunhoferhhi Versatile Video Decoder]
+    echo. 1 = Yes
+    echo. 2 = No
+    echo.
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    set /P buildvvdec="Build vvdec: "
+) else set buildvvdec=%vvdecINI%
+
+if "%buildvvdec%"=="" GOTO vvdec
+if %buildvvdec%==1 set "vvdec=y"
+if %buildvvdec%==2 set "vvdec=n"
+if %buildvvdec% GTR 2 GOTO vvdec
+if %deleteINI%==1 echo.vvdec=^%buildvvdec%>>%ini%
 
 :svtav1
 if %svtav1INI%==0 (

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1748,9 +1748,10 @@ set compileArgs=--cpuCount=%cpuCount% --build32=%build32% --build64=%build64% ^
 --mpv=%mpv% --license=%license2%  --stripping=%stripFile% --packing=%packFile% --rtmpdump=%rtmpdump% ^
 --logging=%logging% --bmx=%bmx% --standalone=%standalone% --aom=%aom% --faac=%faac% --exhale=%exhale% ^
 --ffmbc=%ffmbc% --curl=%curl% --cyanrip=%cyanrip% --rav1e=%rav1e% --ripgrep=%ripgrep% --dav1d=%dav1d% ^
---vvc=%vvc% --uvg266=%uvg266% --jq=%jq% --jo=%jo% --dssim=%dssim% --avs2=%avs2% --timeStamp=%timeStamp% ^
---noMintty=%noMintty% --ccache=%ccache% --svthevc=%svthevc% --svtav1=%svtav1% --svtvp9=%svtvp9% --xvc=%xvc% ^
---vlc=%vlc% --libavif=%libavif% --jpegxl=%jpegxl% --autouploadlogs=%autouploadlogs%
+--vvc=%vvc% --uvg266=%uvg266% --vvenc=%vvenc% --vvdec=%vvdec% --jq=%jq% --jo=%jo% --dssim=%dssim% ^
+--avs2=%avs2% --timeStamp=%timeStamp% --noMintty=%noMintty% --ccache=%ccache% --svthevc=%svthevc% ^
+--svtav1=%svtav1% --svtvp9=%svtvp9% --xvc=%xvc% --vlc=%vlc% --libavif=%libavif% --jpegxl=%jpegxl% ^ 
+--autouploadlogs=%autouploadlogs%
     set "noMintty=%noMintty%"
     if %build64%==yes ( set "MSYSTEM=MINGW64" ) else set "MSYSTEM=MINGW32"
     set "MSYS2_PATH_TYPE=inherit"


### PR DESCRIPTION
See issue: #1810 

Added vvenc & vvdec, but not tested yet, others vvc programs are coming soon...

Update of 16th June 2022: vvenc & vvdec is only now support of media autobuild suite, others were not.

- [X] vvenc & vvdec
- [ ] Bitmovin VVDec Player
- [ ] FFmpeg (libvvdec plugin)
- [ ] VLC InterDigital Plugin?

- Martin Eesmaa