### PR TITLE
Allow specifying a custom ffmpeg source repo

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -35,6 +35,7 @@ while true; do
     --sox=* ) sox=${1#*=} && shift ;;
     --ffmpeg=* ) ffmpeg=${1#*=} && shift ;;
     --ffmpegUpdate=* ) ffmpegUpdate=${1#*=} && shift ;;
+    --ffmpegPath=* ) ffmpegPath="${1#*=}"; shift ;;
     --ffmpegChoice=* ) ffmpegChoice=${1#*=} && shift ;;
     --mplayer=* ) mplayer=${1#*=} && shift ;;
     --mpv=* ) mpv=${1#*=} && shift ;;
@@ -1515,7 +1516,7 @@ if [[ $x264 != no ]] ||
         unset_extra_script
         if [[ $standalone = y && $x264 =~ (full|fullv) ]]; then
             _check=("$LOCALDESTDIR"/opt/lightffmpeg/lib/pkgconfig/libav{codec,format}.pc)
-            do_vcs "https://git.ffmpeg.org/ffmpeg.git"
+            do_vcs "$ffmpegPath"
             do_uninstall "$LOCALDESTDIR"/opt/lightffmpeg
             [[ -f config.mak ]] && log "distclean" make distclean
             create_build_dir light
@@ -2033,7 +2034,7 @@ if [[ $ffmpeg != no ]]; then
     # todo: make this more easily customizable
     [[ $ffmpegUpdate = y ]] && enabled_any lib{aom,tesseract,vmaf,x265,vpx} &&
         _deps=(lib{aom,tesseract,vmaf,x265,vpx}.a)
-    if do_vcs "https://git.ffmpeg.org/ffmpeg.git"; then
+    if do_vcs "$ffmpegPath"; then
         do_changeFFmpegConfig "$license"
         [[ -f ffmpeg_extra.sh ]] && source ffmpeg_extra.sh
         if enabled libsvthevc; then
@@ -2228,7 +2229,7 @@ if [[ $mplayer = y ]] && check_mplayer_updates; then
     if [[ ! -d ffmpeg ]] &&
         ! { [[ -d $LOCALBUILDDIR/ffmpeg-git ]] &&
         git clone -q "$LOCALBUILDDIR/ffmpeg-git" ffmpeg; } &&
-        ! git clone "https://git.ffmpeg.org/ffmpeg.git" ffmpeg; then
+        ! git clone "$ffmpegPath" ffmpeg; then
         rm -rf ffmpeg
         printf '%s\n' \
             "Failed to get a FFmpeg checkout" \
@@ -2526,7 +2527,7 @@ if [[ $cyanrip = y ]]; then
     if do_vcs "https://github.com/cyanreg/cyanrip.git"; then
         old_PKG_CONFIG_PATH=$PKG_CONFIG_PATH
         _check=("$LOCALDESTDIR"/opt/cyanffmpeg/lib/pkgconfig/libav{codec,format}.pc)
-        if flavor=cyan do_vcs "https://git.ffmpeg.org/ffmpeg.git"; then
+        if flavor=cyan do_vcs "$ffmpegPath"; then
             do_uninstall "$LOCALDESTDIR"/opt/cyanffmpeg
             [[ -f config.mak ]] && log "distclean" make distclean
             mapfile -t cyan_ffmpeg_opts < <(


### PR DESCRIPTION
This patch allows to specify a path to a custom ffmpeg repo in the `media_autobuild_suite.ini` file:

![image](https://user-images.githubusercontent.com/4985349/198108336-441ff8e2-a431-4ce9-90a8-8ef912b9c926.png)

It can be a URL or a local path.