### PR TITLE
Disable use of MASM for Vulkan-Loader

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1950,7 +1950,7 @@ if { { [[ $ffmpeg != no ]] && enabled_any vulkan libplacebo; } ||
     do_print_progress "Building Vulkan-Loader"
     CFLAGS+=" -DSTRSAFE_NO_DEPRECATE" do_cmakeinstall -DBUILD_TESTS=OFF -DUSE_CCACHE=OFF \
     -DUSE_UNSAFE_C_GEN=ON -DVULKAN_HEADERS_INSTALL_DIR="$LOCALDESTDIR" \
-    -DBUILD_STATIC_LOADER=ON -DUNIX=OFF -DENABLE_WERROR=OFF
+    -DBUILD_STATIC_LOADER=ON -DUNIX=OFF -DENABLE_WERROR=OFF -DUSE_MASM=OFF
     do_checkIfExist
     unset _DeadSix27 _mabs _shinchiro
 fi


### PR DESCRIPTION
Not performance critical MinGW/GCC compatibility workaround

Vulkan-Loader did not support MinGW with a separate tool chain yet.

Fixes #2455 
