### PR TITLE
Ogg to be installed before vorbis

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -680,6 +680,17 @@ fi
 
 grep_or_sed stdc++ "$(file_installed libilbc.pc)" "/Libs:/ a\Libs.private: -lstdc++"
 
+_check=(libogg.{l,}a ogg/ogg.h ogg.pc)
+if {
+    [[ $flac = y ]] ||
+    { [[ $standalone = y ]] && enabled libvorbis; }
+    } && do_vcs "$SOURCE_REPO_LIBOGG"; then
+    do_uninstall include/ogg "${_check[@]}"
+    do_autogen
+    do_separate_confmakeinstall audio
+    do_checkIfExist
+fi
+
 _check=(libvorbis{,enc,file}.{,l}a vorbis{,enc,file}.pc vorbis/vorbisenc.h)
 if enabled libvorbis && do_vcs "$SOURCE_REPO_LIBVORBIS"; then
     do_uninstall include/vorbis "${_check[@]}"
@@ -697,17 +708,6 @@ if enabled libspeex && do_vcs "$SOURCE_REPO_SPEEX"; then
     extracommands=()
     [[ $standalone = y ]] || extracommands+=(--disable-binaries)
     do_separate_confmakeinstall audio --enable-vorbis-psy "${extracommands[@]}"
-    do_checkIfExist
-fi
-
-_check=(libogg.{l,}a ogg/ogg.h ogg.pc)
-if {
-    [[ $flac = y ]] ||
-    { [[ $standalone = y ]] && enabled libvorbis; }
-    } && do_vcs "$SOURCE_REPO_LIBOGG"; then
-    do_uninstall include/ogg "${_check[@]}"
-    do_autogen
-    do_separate_confmakeinstall audio
     do_checkIfExist
 fi
 


### PR DESCRIPTION
Vorbis depends on ogg, so it must be downloaded and installed first.

Fixes #2491 

<!--
Description

(Optional) 
--->
