### PR TITLE
Small fixes to shaderc and mpv (with info on luajit)

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1994,14 +1994,7 @@ _check=(shaderc/shaderc.h libshaderc_combined.a)
         do_patch "https://raw.githubusercontent.com/m-ab-s/mabs-patches/master/shaderc/0002-shaderc_util-add-install.patch" am
         do_uninstall "${_check[@]}" include/shaderc include/libshaderc_util
 
-        cd third_party
-
-        do_vcs_local "$SOURCE_REPO_GLSLANG" glslang
-        do_vcs_local "$SOURCE_REPO_SPIRV_TOOLS" spirv-tools
-        do_vcs_local "$SOURCE_REPO_SPIRV_HEADERS" spirv-headers
-        do_vcs_local "$SOURCE_REPO_SPIRV_CROSS" spirv-cross
-
-        cd ..
+        log dependencies /usr/bin/python ./utils/git-sync-deps
 
         # fix python indentation errors from non-existant code review
         grep -ZRlP --include="*.py" '\t' third_party/spirv-tools/ | xargs -r -0 -n1 sed -i 's;\t;    ;g'

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -71,7 +71,7 @@ SOURCE_REPO_LIBXML2=https://gitlab.gnome.org/GNOME/libxml2.git
 SOURCE_REPO_LIBZEN=https://github.com/MediaArea/ZenLib.git
 SOURCE_REPO_LUAJIT=https://github.com/LuaJIT/LuaJIT.git
 SOURCE_REPO_MEDIAINFO=https://github.com/MediaArea/MediaInfo.git
-SOURCE_REPO_MPV=https://github.com/mpv-player/mpv.git#commit=f2cce5f38f4031bf1a4b4919ec90e4e8f8c66a77~1
+SOURCE_REPO_MPV=https://github.com/mpv-player/mpv.git#0.36
 SOURCE_REPO_MUJS=https://github.com/ccxvii/mujs.git
 SOURCE_REPO_NEON=https://github.com/notroj/neon.git
 SOURCE_REPO_OPENAL=https://github.com/kcat/openal-soft.git

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -71,7 +71,7 @@ SOURCE_REPO_LIBXML2=https://gitlab.gnome.org/GNOME/libxml2.git
 SOURCE_REPO_LIBZEN=https://github.com/MediaArea/ZenLib.git
 SOURCE_REPO_LUAJIT=https://github.com/LuaJIT/LuaJIT.git
 SOURCE_REPO_MEDIAINFO=https://github.com/MediaArea/MediaInfo.git
-SOURCE_REPO_MPV=https://github.com/mpv-player/mpv.git#0.36
+SOURCE_REPO_MPV=https://github.com/mpv-player/mpv.git#tag=v0.36.0
 SOURCE_REPO_MUJS=https://github.com/ccxvii/mujs.git
 SOURCE_REPO_NEON=https://github.com/notroj/neon.git
 SOURCE_REPO_OPENAL=https://github.com/kcat/openal-soft.git


### PR DESCRIPTION
A couple of small fixes to help get the suite back on track.  It basically just pins mpv to the 0.36 release tag, since they removed waf completely after that, thus making newer revs unable to be compiled by the suite for now.  I noted that a prior PR was submitted to update mpv's build procedures, so this should help band-aid mpv until you get that worked out.

The shaderc portion removes the cloning of the dependencies into third-party and just runs the git-sync-deps script included with shaderc.  This should pull the known-good commits for each dependency (as listed in the DEPS file), which not only follows their build docs, but also should cut down on the frequency that shaderc compilation breaks because they haven't accounted for upstream dependency changes yet.

Somewhat unrelated to this PR, but to explain the luajit reference in the branch name....
I also made a patch for luajit, since that broke recently as well.  They went to a rolling release scheme for their install and uninstall Makefile targets, meaning they copy a <name>-<version> binary into bindir, then add a generically named symlink pointing to the freshly installed version.  This caused issues because the suite is overriding INSTALL_TNAME at install time, but used "luajit.exe" which happened to be the same as the symlink name (INSTALL_TSYM)...meaning it tried linking luajit.exe to luajit.exe.  Uninstall would also not always remove older versions since it only looks for versioned names that match what's in the Makefile (so it can only remove its own version).  As a result and to cut down on old versioned binaries building up in bin-global, I thought it best to just revert the rolling release/symlink bits in the Makefile so it just installs the binary the same way the suite is used to it being done.

The alternative (which I also tried) for luajit is to change the INSTALL_TNAME override in media-suite_compile.sh to INSTALL_TSYM instead, but I ended up with three different version-named luajit binaries in my bin-global in just two days.  That's going to build up for people who recompile frequently and it's likely not useful to keep those around in this context.

I can submit that luajit patch to mabs-patches and do a PR here to add it to media-suite_compile.sh, if you'd like...or I can just paste it here...or paste it into a bug report.  It's a small patch and just requires a one-liner addition to media-suite_compile.sh, so it shouldn't be a big deal.