### PR TITLE
more compiletime/runtime security; add to brotli .pc files

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -426,9 +426,10 @@ if [[ $mediainfo = y || $bmx = y || $curl != n ]]; then
 fi
 
 do_pacman_install brotli
-grep_and_sed '-lbrotlidec' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlidec.pc \
+# if brotlicommon not already added, then add it to the brotli .pc files
+grep_or_sed '-lbrotlidec -lbrotlicommon' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlidec.pc \
         's|-lbrotlidec|-lbrotlidec -lbrotlicommon|g' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlidec.pc 
-grep_and_sed '-lbrotlienc' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlienc.pc \
+grep_or_sed '-lbrotlienc -lbrotlicommon' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlienc.pc \
         's|-lbrotlienc|-lbrotlienc -lbrotlicommon|g' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlienc.pc 
 
 _check=(curl/curl.h libcurl.{{,l}a,pc})

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -426,6 +426,10 @@ if [[ $mediainfo = y || $bmx = y || $curl != n ]]; then
 fi
 
 do_pacman_install brotli
+grep_and_sed '-lbrotlidec' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlidec.pc \
+        's|-lbrotlidec|-lbrotlidec -lbrotlicommon|g' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlidec.pc 
+grep_and_sed '-lbrotlienc' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlienc.pc \
+        's|-lbrotlienc|-lbrotlienc -lbrotlicommon|g' "$MINGW_PREFIX"/lib/pkgconfig/libbrotlienc.pc 
 
 _check=(curl/curl.h libcurl.{{,l}a,pc})
 case $curl in

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1922,13 +1922,13 @@ goto :EOF
     echo.ACLOCAL_PATH="${LOCALDESTDIR}/share/aclocal:${MINGW_PREFIX}/share/aclocal:/usr/share/aclocal"
     echo.PKG_CONFIG="${MINGW_PREFIX}/bin/pkgconf --keep-system-libs --keep-system-cflags --static"
     echo.PKG_CONFIG_PATH="${LOCALDESTDIR}/lib/pkgconfig:${MINGW_PREFIX}/lib/pkgconfig"
-    echo.CPPFLAGS="-D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1"
-    echo.CFLAGS="-fstack-protector-strong -mtune=generic -O2 -pipe"
+    echo.CPPFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1"
+    echo.CFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe"
     if %CC%==gcc (
         echo.CFLAGS+=" -mthreads"
     )
     echo.CXXFLAGS="${CFLAGS}"
-    echo.LDFLAGS="-pipe -static-libgcc -fstack-protector-strong"
+    echo.LDFLAGS="-pipe -static-libgcc -fstack-protector-strong -D_FORTIFY_SOURCE=2"
     if %CC%==clang (
         echo.LDFLAGS+=" --start-no-unused-arguments -static-libstdc++ --end-no-unused-arguments"
     ) else (


### PR DESCRIPTION
1. Update environment FLAGS with
```-fstack-protector-strong -D_FORTIFY_SOURCE=2```
to be consistent across the flags.

Reasoning:
There are a large number of very complex 3rd party dependencies maintained by 3rd parties which, whilst notionally safe at first glance, may introduce security issues. Nowadays especially, that's the last thing anyone needs.
Let's bake a tiny bit of checking into the build ... if people don't like it then they can always change it themselves.

2. fix the brotli brotlicommon not found during linking issue 
if brotlicommon not already added, then add it to the brotli .pc files
