### PR TITLE
media-suite_deps.sh: set GIT tag to v0.8.2 for libjxl - Fixes #2521

### DIFF
--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -43,7 +43,7 @@ SOURCE_REPO_LIBDVDNAV=https://code.videolan.org/videolan/libdvdnav.git
 SOURCE_REPO_LIBDVDREAD=https://code.videolan.org/videolan/libdvdread.git
 SOURCE_REPO_LIBGLUT=https://github.com/dcnieho/FreeGLUT.git
 SOURCE_REPO_LIBILBC=https://github.com/TimothyGu/libilbc.git
-SOURCE_REPO_LIBJXL=https://github.com/libjxl/libjxl.git
+SOURCE_REPO_LIBJXL=https://github.com/libjxl/libjxl.git#tag=v0.8.2
 SOURCE_REPO_LIBKVAZAAR=https://github.com/ultravideo/kvazaar.git
 SOURCE_REPO_LIBLSMASH=https://github.com/l-smash/l-smash.git
 SOURCE_REPO_LIBMEDIAINFO=https://github.com/MediaArea/MediaInfoLib.git


### PR DESCRIPTION
Fixes https://github.com/m-ab-s/media-autobuild_suite/issues/2521
Fixes https://github.com/m-ab-s/media-autobuild_suite/issues/2563

Description:
Current git tag for libjxl library creates following compile error:

Likely error (tail of the failed operation logfile):
O:/ffmpeg/build/libjxl-git/lib/jxl/jxl_cms.cc:1003:9: error: 'struct jxl::ColorEncoding' has no member named 'rendering_intent'; did you mean 'GetRenderingIntent'?
1003 | c_enc.rendering_intent = static_cast(rendering_intent32);
| ^~~~~~~~~~~~~~~~
| GetRenderingIntent
O:/ffmpeg/build/libjxl-git/lib/jxl/jxl_cms.cc: In function 'void* jxl::{anonymous}::JxlCmsInit(void*, size_t, size_t, const JxlColorProfile*, const JxlColorProfile*, float)':
O:/ffmpeg/build/libjxl-git/lib/jxl/jxl_cms.cc:1234:55: error: 'struct jxl::ColorEncoding' has no member named 'rendering_intent'; did you mean 'GetRenderingIntent'?
1234 | const uint32_t intent = static_cast<uint32_t>(c_dst.rendering_intent);
| ^~~~~~~~~~~~~~~~
| GetRenderingIntent
ninja: build stopped: subcommand failed.
build failed. Check O:/ffmpeg/build/libjxl-git/build-64bit/ab-suite.build.log