### PR TITLE
fix: #2580 remove standalone condition for ogg compilation

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -680,10 +680,8 @@ fi
 grep_or_sed stdc++ "$(file_installed libilbc.pc)" "/Libs:/ a\Libs.private: -lstdc++"
 
 _check=(libogg.{l,}a ogg/ogg.h ogg.pc)
-if {
-    [[ $flac = y ]] ||
-    { [[ $standalone = y ]] && enabled libvorbis; }
-    } && do_vcs "$SOURCE_REPO_LIBOGG"; then
+if { [[ $flac = y ]] || enabled libvorbis; } &&
+    do_vcs "$SOURCE_REPO_LIBOGG"; then
     do_uninstall include/ogg "${_check[@]}"
     do_autogen
     do_separate_confmakeinstall audio


### PR DESCRIPTION
The Ogg library is required to compile Vorbis.
Ogg is only compiled when standalone binaries were requested.

Vorbis compilation fails as ogg is missing when standalone librairies are not resqested

=> remove the standalone condition for compiling ogg

Corrections #2580