### PR TITLE
Curl url

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -442,7 +442,7 @@ mbedtls) _deps=("$MINGW_PREFIX/lib/libmbedtls.a") ;;
 esac
 [[ $standalone = y || $curl != n ]] && _check+=(bin-global/curl.exe)
 if [[ $mediainfo = y || $bmx = y || $curl != n || $cyanrip = y ]] &&
-    do_vcs "https://github.com/curl/curl.git"; then
+    do_vcs "$SOURCE_REPO_CURL"; then
     do_pacman_install nghttp2
 
     do_uninstall include/curl bin-global/curl-config "${_check[@]}"

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -7,6 +7,7 @@ SOURCE_REPO_ARRIB24=https://github.com/nkoriyama/aribb24.git
 SOURCE_REPO_AVISYNTH=https://github.com/AviSynth/AviSynthPlus.git
 SOURCE_REPO_CARGOC=https://github.com/lu-zero/cargo-c.git
 SOURCE_REPO_CODEC2=https://github.com/drowe67/codec2.git
+SOURCE_REPO_CURL=https://github.com/curl/curl.git
 SOURCE_REPO_CYANRIP=https://github.com/cyanreg/cyanrip.git
 SOURCE_REPO_DAV1D=https://code.videolan.org/videolan/dav1d.git
 SOURCE_REPO_DAVS=https://github.com/pkuvcl/davs2.git


### PR DESCRIPTION
<!--
Description

(Optional) Fixes #[issueNumber]
--->
Moves curl URL into `media-suite_deps.sh` instead of hardcoding it into the build script.

This makes it easier to override with a specific tag/branch to prevent wasting an hour recompiling curl while troubleshooting other m-ab-s issues since there absolutely _had_ to be a second, separate commit to curl/master to fix documentation or something equally silly.