### PR TITLE
Add harfbuzz to zeranoe options

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -118,7 +118,7 @@ libdav1d libaom --disable-debug libfdk-aac
 
 :: options used in zeranoe builds and not present above
 set ffmpeg_options_zeranoe=fontconfig gnutls libass libbluray libfreetype ^
-libmfx libmysofa libopencore-amrnb libopencore-amrwb libopenjpeg libsnappy ^
+libharfbuzz libmfx libmysofa libopencore-amrnb libopencore-amrwb libopenjpeg libsnappy ^
 libsoxr libspeex libtheora libtwolame libvidstab libvo-amrwbenc ^
 libwebp libxml2 libzimg libshine gpl openssl libtls avisynth mbedtls libxvid ^
 libopenmpt version3 librav1e libsrt libgsm libvmaf libsvtav1


### PR DESCRIPTION
harfbuzz has been made a dep for the drawtext filter but isn't passed as an arg to ffmpeg configure, so the filter isn't present in builds
