### PR TITLE
Some package installation changes

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -175,6 +175,10 @@ if [[ $packing = y &&
     do_install upx.exe /opt/bin/upx.exe
 fi
 
+if [[ "$ripgrep|$rav1e|$dssim|$libavif|$dovitool|$hdr10plustool" = *y* ]] || enabled librav1e; then
+    do_pacman_install rust
+fi
+
 _check=(bin-global/rg.exe)
 if [[ $ripgrep = y ]] &&
     do_vcs "https://github.com/BurntSushi/ripgrep.git"; then

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -106,7 +106,7 @@ intltool libtool patch python xmlto make zip unzip git subversion wget p7zip man
 gperf winpty texinfo gyp doxygen autoconf-archive itstool ruby mintty flex msys2-runtime pacutils
 
 set mingwpackages=cmake dlfcn libpng nasm pcre tools-git yasm ninja pkgconf meson ccache jq ^
-clang gettext-tools lld rust
+clang gettext-tools rust
 
 :: built-ins
 set ffmpeg_options_builtin=--disable-autodetect amf bzlib cuda cuvid d3d11va dxva2 ^
@@ -1752,7 +1752,7 @@ for %%i in (%instdir%\msys64\usr\ssl\cert.pem) do if %%~zi==0 call :runBash cert
 rem installmingw
 rem extra package for clang
 if %CC%==clang (
-    set "mingwpackages=%mingwpackages% gcc-compat"
+    set "mingwpackages=%mingwpackages% gcc-compat lld"
 ) else (
     set "mingwpackages=%mingwpackages% binutils gcc"
 )

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -106,7 +106,7 @@ intltool libtool patch python xmlto make zip unzip git subversion wget p7zip man
 gperf winpty texinfo gyp doxygen autoconf-archive itstool ruby mintty flex msys2-runtime pacutils
 
 set mingwpackages=cmake dlfcn libpng nasm pcre tools-git yasm ninja pkgconf meson ccache jq ^
-clang gettext-tools rust
+clang gettext-tools
 
 :: built-ins
 set ffmpeg_options_builtin=--disable-autodetect amf bzlib cuda cuvid d3d11va dxva2 ^


### PR DESCRIPTION
* Move `do_pacman_install` calls before any `do_vcs|wget|pkgConfig` calls so that no dependencies are missing if the msys64 folder is deleted. Dependencies required only during compilation are called after `do_vcs|wget|pkgConfig`.
* Install lld for clang only, as it isn't used for gcc compilation. (save 40MB for 32/64bit, 80MB for both)
* Install rust only when a rust library is enabled. (if no rust library is built, saves 400MB for 32/64bit, 800MB for both)