### PR TITLE
Remove alternative vapoursynth demuxer from ffmpeg

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2254,8 +2254,6 @@ if [[ $ffmpeg != no ]]; then
         enabled libsvtav1 || do_removeOption FFMPEG_OPTS_SHARED "--enable-libsvtav1"
         enabled libsvtvp9 || do_removeOption FFMPEG_OPTS_SHARED "--enable-libsvtvp9"
 
-        enabled vapoursynth && do_patch "https://raw.githubusercontent.com/m-ab-s/mabs-patches/master/ffmpeg/0001-Add-Alternative-VapourSynth-demuxer.patch" am
-
         if enabled openal &&
             pc_exists "openal"; then
             OPENAL_LIBS=$($PKG_CONFIG --libs openal)


### PR DESCRIPTION
In a benchmark against the current multithreaded vapoursynth demuxer included in ffmpeg 7 and vspipe as external provider, the alternative demuxer was the slowest by far. Efforts to fix the patch being linkable again seem to have low priority, if any at all.

Fixes #2766 

