### PR TITLE
vulkan-loader: remove windows-Static-linking-hacks.patch

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2037,7 +2037,6 @@ if { { [[ $ffmpeg != no ]] && enabled_any vulkan libplacebo; } ||
     do_pacman_install uasm
     do_uninstall "${_check[@]}"
     do_patch "$_mabs/0001-pc-remove-CMAKE_CXX_IMPLICIT_LINK_LIBRARIES.patch" am
-    do_patch "$_mabs/0002-loader-loader_windows-Static-linking-hacks.patch" am
     do_patch "$_mabs/0003-loader-CMake-related-static-hacks.patch" am
     do_patch "$_mabs/0004-loader-Re-add-private-libs-to-pc-file.patch" am
     do_patch "$_mabs/0005-loader-Static-library-name-related-hacks.patch" am


### PR DESCRIPTION
Patch failed, built anyway. So it is probably implemented now.