### PR TITLE
Minimize Clang usage in MINGW envs

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1979,6 +1979,7 @@ if [[ $av1an != n ]]; then
     _check=("$av1an_bindir"/av1an.exe)
     if do_vcs "$SOURCE_REPO_AV1AN"; then
         do_uninstall "${_check[@]}"
+        do_pacman_install clang
         PKG_CONFIG="$LOCALDESTDIR/bin/ab-pkg-config-static.bat" \
             VAPOURSYNTH_LIB_DIR="$LOCALDESTDIR/lib" do_rust
         do_install "target/$CARCH-pc-windows-gnu$rust_target_suffix/release/av1an.exe" $av1an_bindir/

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1198,8 +1198,6 @@ if { [[ $rav1e = y ]] || [[ $libavif = y ]] || enabled librav1e; } &&
     if [[ $libavif = y ]] || enabled librav1e; then
         rm -f "$CARGO_HOME/config" 2> /dev/null
         PKG_CONFIG="$LOCALDESTDIR/bin/ab-pkg-config-static.bat" \
-            CC="ccache clang" \
-            CXX="ccache clang++" \
             log "install-rav1e-c" cargo capi install \
             --release --jobs "$cpuCount" --prefix="$LOCALDESTDIR" \
             --destdir="$PWD/install-$bits"

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1408,7 +1408,6 @@ do_rust() {
     [[ -f "$(get_first_subdir -f)/do_not_reconfigure" ]] &&
         return
     PKG_CONFIG_ALL_STATIC=true \
-        CC="ccache clang" \
         log "rust.build" cargo build \
         --target="$CARCH"-pc-windows-gnu$target_suffix \
         --jobs="$cpuCount" "${@:---release}" "${rust_extras[@]}"
@@ -1425,7 +1424,6 @@ do_rustinstall() {
     [[ -f "$(get_first_subdir -f)/do_not_reconfigure" ]] &&
         return
     PKG_CONFIG_ALL_STATIC=true \
-        CC="ccache clang" \
         PKG_CONFIG="$LOCALDESTDIR/bin/ab-pkg-config" \
         log "rust.install" cargo install \
         --target="$CARCH"-pc-windows-gnu$target_suffix \
@@ -1443,7 +1441,6 @@ do_rustcinstall() {
     [[ -f "$(get_first_subdir -f)/do_not_reconfigure" ]] &&
         return
     PKG_CONFIG_ALL_STATIC=true \
-        CC="ccache clang" \
         PKG_CONFIG="$LOCALDESTDIR/bin/ab-pkg-config" \
         log "rust.cinstall" cargo cinstall \
         --target="$CARCH"-pc-windows-gnu$target_suffix \

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -106,7 +106,7 @@ intltool libtool patch python xmlto make zip unzip git subversion wget p7zip man
 gperf winpty texinfo gyp doxygen autoconf-archive itstool ruby mintty flex msys2-runtime pacutils
 
 set mingwpackages=cmake dlfcn libpng nasm pcre tools-git yasm ninja pkgconf meson ccache jq ^
-clang gettext-tools
+gettext-tools
 
 :: built-ins
 set ffmpeg_options_builtin=--disable-autodetect amf bzlib cuda cuvid d3d12va d3d11va dxva2 ^
@@ -1788,7 +1788,7 @@ for %%i in (%instdir%\msys64\usr\ssl\cert.pem) do if %%~zi==0 call :runBash cert
 rem installmingw
 rem extra package for clang
 if %CC%==clang (
-    set "mingwpackages=%mingwpackages% gcc-compat lld"
+    set "mingwpackages=%mingwpackages% clang gcc-compat lld"
 ) else (
     set "mingwpackages=%mingwpackages% binutils gcc"
 )
@@ -2058,8 +2058,10 @@ goto :EOF
 :getmingw
 setlocal
 set found=0
-set "compilers=%instdir%\msys64\mingw%1\bin\gcc.exe %instdir%\msys64\clang%1\bin\clang.exe"
-for %%i in (%compilers%) do if exist %%i set found=1
+if %CC%==clang (
+    set "compiler=%instdir%\msys64\clang%1\bin\clang.exe"
+) else set "compiler=%instdir%\msys64\mingw%1\bin\gcc.exe"
+if exist %compiler% set found=1
 if %found%==1 GOTO :EOF
 echo.-------------------------------------------------------------------------------
 echo.install %1 bit compiler
@@ -2083,7 +2085,7 @@ if %CC%==clang (
 )>%build%\mingw.sh
 call :runBash mingw%1.log /build/mingw.sh
 
-for %%i in (%compilers%) do if exist %%i set found=1
+if exist %compiler% set found=1
 if %found%==0 (
     echo -------------------------------------------------------------------------------
     echo.


### PR DESCRIPTION
Since the suite installs rust via msys2 instead of rustup, [this commit](https://github.com/m-ab-s/media-autobuild_suite/commit/87ece8ec16088504a341f812706aba944f13dcd8) is no longer necessary since [the issue it works around](https://github.com/m-ab-s/media-autobuild_suite/issues/2207#issuecomment-1152897236) isn't encountered on msys2's rust. All rust libraries build fine after this change, and also appear to run fine (tested Av1an, rav1e, and dssim).

This also means Clang is no longer a strict requirement for building on MINGW32/64, so ~1GB can be saved when the suite is installed for the first time. Clang now only installs when building Av1an or ffmpeg with cuda-llvm enabled, since they both require libclang to compile.