### PR TITLE
prevent superfluous clang installation during FFmpeg compilation

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -2358,11 +2358,13 @@ verify_cuda_deps() {
     if enabled libnpp && [[ ! -f "$CUDA_PATH/lib/x64/nppc.lib" ]]; then
         do_removeOption --enable-libnpp
     fi
-    if ! disabled cuda-llvm && do_pacman_install clang; then
+    if enabled cuda-llvm && do_pacman_install clang; then
         do_removeOption --enable-cuda-nvcc
     else
         do_removeOption --enable-cuda-llvm
-        do_addOption --disable-cuda-llvm
+        if ! disabled autodetect; then
+            do_addOption --disable-cuda-llvm
+        fi
     fi
     if enabled cuda-nvcc; then
         if ! get_cl_path; then


### PR DESCRIPTION
Although cuda-llvm is included in default ffmpeg options, when using custom ffmpeg options, if the cuda-llvm is not explicitly disabled (it should be implicitly disabled by --disable-autodetect which is default option too) it will move on to install the clang package.

If a user, now, after the removal of clang from default packages, and is using GCC toolchain, "implicitly disabled" cuda-llvm by remove or comment out the line in ffmpeg_options, the clang package will be installed without any actual use.

I'm not entirely sure what this part of the code is intended for, maybe this is not the best way to prevent it.