### PR TITLE
suite: download less packages on first install

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1343,6 +1343,7 @@ do_cmake() {
         return
     # shellcheck disable=SC2086
     log "cmake" cmake "$root" -G Ninja -DBUILD_SHARED_LIBS=off \
+        -DPython3_EXECUTABLE="${MINGW_PREFIX}/bin/python.exe" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
         -DCMAKE_TOOLCHAIN_FILE="$LOCALDESTDIR/etc/toolchain.cmake" \
         -DCMAKE_INSTALL_PREFIX="$LOCALDESTDIR" -DUNIX=on \

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -101,12 +101,10 @@ do if %%f lss 4 (
 set build=%instdir%\build
 if not exist %build% mkdir %build%
 
-set msyspackages=asciidoc autoconf-wrapper automake-wrapper autogen base bison diffstat dos2unix filesystem help2man ^
-intltool libtool patch python xmlto make zip unzip git subversion wget p7zip man-db ^
-gperf winpty texinfo gyp doxygen autoconf-archive itstool ruby mintty flex msys2-runtime pacutils
+set msyspackages=autoconf-archive autoconf-wrapper autogen automake-wrapper base dos2unix ^
+filesystem git libtool make msys2-runtime patch pacutils p7zip subversion unzip winpty
 
-set mingwpackages=cmake dlfcn libpng nasm pcre tools-git yasm ninja pkgconf meson ccache jq ^
-gettext-tools
+set mingwpackages=ccache cmake dlfcn gettext-tools meson nasm ninja pkgconf
 
 :: built-ins
 set ffmpeg_options_builtin=--disable-autodetect amf bzlib cuda cuvid d3d12va d3d11va dxva2 ^


### PR DESCRIPTION
Reduce the number of packages installed when the suite is first run, which saves about 350MB (2.40GB -> 2.05GB on MINGW64)

Since the msys version of python is no longer installed with this change, the mingw version is specified whenever python is called. Tested on MINGW64 and everything compiled fine