### PR TITLE
suite: add gifski

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ For information about the compiler environment see the wiki, there you also have
     - fdk-aac (git)
     - ffmbc (git) (unsupported)
     - flac (git)
+    - gifski (git)
+        - with optional built-in video support (ffmpeg 6.1)
     - haisrt tools (git)
     - jo (git)
     - jpeg-xl tools (git)

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -29,6 +29,7 @@ SOURCE_REPO_FREETYPE=https://github.com/freetype/freetype.git#tag=LATEST
 SOURCE_REPO_FREI0R=https://github.com/dyne/frei0r.git
 SOURCE_REPO_FRIBIDI=https://github.com/fribidi/fribidi.git
 SOURCE_REPO_GFLAGS=https://github.com/gflags/gflags.git
+SOURCE_REPO_GIFSKI=https://github.com/ImageOptim/gifski.git
 SOURCE_REPO_GLSLANG=https://github.com/KhronosGroup/glslang.git
 SOURCE_REPO_GPAC=https://github.com/gpac/gpac.git
 SOURCE_REPO_HARFBUZZ=https://github.com/harfbuzz/harfbuzz.git

--- a/doc/forcing-recompilations.md
+++ b/doc/forcing-recompilations.md
@@ -143,6 +143,7 @@ To recompile these, delete `<appname>.exe` in corresponding binary directories:
         djxl
         dssim
         dwebp
+        gifski
         idn2
         img2webp
         jxlinfo

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -145,7 +145,7 @@ set mpv_options_full=dvdnav cdda #egl-angle #html-build ^
 set iniOptions=arch license2 vpx2 x2643 x2652 other265 flac fdkaac mediainfo ^
 soxB ffmpegB2 ffmpegUpdate ffmpegChoice mp4box rtmpdump mplayer2 mpv cores deleteSource ^
 strip pack logging bmx standalone updateSuite av1an aom faac exhale ffmbc curl cyanrip2 ^
-rav1e ripgrep dav1d libavif vvc uvg266 jq dssim avs2 dovitool hdr10plustool timeStamp ^
+rav1e ripgrep dav1d libavif vvc uvg266 jq dssim gifski avs2 dovitool hdr10plustool timeStamp ^
 noMintty ccache svthevc svtav1 svtvp9 xvc jo vlc CC jpegxl vvenc vvdec ffmpegPath pkgUpdateTime
 @rem re-add autouploadlogs if we find some way to upload to github directly instead
 
@@ -1270,6 +1270,28 @@ if %builddssim%==2 set "dssim=n"
 if %builddssim% GTR 2 GOTO dssim
 if %deleteINI%==1 echo.dssim=^%builddssim%>>%ini%
 
+:gifski
+if [0]==[%gifskiINI%] (
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    echo.
+    echo. Build gifski (high quality GIF encoder in Rust^)?
+    echo. 1 = Yes
+    echo. 2 = With built-in video support
+    echo. 3 = No
+    echo.
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    set /P buildgifski="Build gifski: "
+) else set buildgifski=%gifskiINI%
+
+if "%buildgifski%"=="" GOTO gifski
+if %buildgifski%==1 set "gifski=y"
+if %buildgifski%==2 set "gifski=video"
+if %buildgifski%==3 set "gifski=n"
+if %buildgifski% GTR 3 GOTO gifski
+if %deleteINI%==1 echo.gifski=^%buildgifski%>>%ini%
+
 :avs2
 if [0]==[%avs2INI%] (
     echo -------------------------------------------------------------------------------
@@ -1903,7 +1925,7 @@ set compileArgs=--cpuCount=%cpuCount% --build32=%build32% --build64=%build64% ^
 --logging=%logging% --bmx=%bmx% --standalone=%standalone% --aom=%aom% --faac=%faac% --exhale=%exhale% ^
 --ffmbc=%ffmbc% --curl=%curl% --cyanrip=%cyanrip% --rav1e=%rav1e% --ripgrep=%ripgrep% --dav1d=%dav1d% ^
 --vvc=%vvc% --uvg266=%uvg266% --vvenc=%vvenc% --vvdec=%vvdec% --jq=%jq% --jo=%jo% --dssim=%dssim% ^
---avs2=%avs2% --dovitool=%dovitool% --hdr10plustool=%hdr10plustool% --timeStamp=%timeStamp% ^
+--gifski=%gifski% --avs2=%avs2% --dovitool=%dovitool% --hdr10plustool=%hdr10plustool% --timeStamp=%timeStamp% ^
 --noMintty=%noMintty% --ccache=%ccache% --svthevc=%svthevc% --svtav1=%svtav1% --svtvp9=%svtvp9% ^
 --xvc=%xvc% --vlc=%vlc% --libavif=%libavif% --jpegxl=%jpegxl% --av1an=%av1an% ^
 --ffmpegPath=%ffmpegPath% --exitearly=%MABS_EXIT_EARLY%


### PR DESCRIPTION
Adds gifski, a high quality gif encoder in Rust. I've also included the option to build gifski with built-in video support via ffmpeg 6.1, because it's apparently [very difficult](https://github.com/ImageOptim/gifski/?tab=readme-ov-file#with-built-in-video-support) to set up (none of the Windows releases have video support).