### PR TITLE
suite: add option to compile zlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ For information about the compiler environment see the wiki, there you also have
     - x265 (8, 10 and 12 bit) (git)
     - xvc (git) (unsupported)
     - xvid (git)
+    - zlib (git or mingw-w64)
+        - minizip, miniunzip (git)
+    - zlib (Chromium fork, git)
+        - minizip, minigzip (git)
+    - zlib (Cloudflare fork, git)
+        - minigzip (git)
+    - zlib-ng (git)
+        - minizip, minigzip (minizip-ng, git)
+    - zlib-rs (git)
 
 --------
 

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -81,6 +81,7 @@ SOURCE_REPO_LIBZEN=https://github.com/MediaArea/ZenLib.git
 SOURCE_REPO_LUAJIT=https://github.com/LuaJIT/LuaJIT.git
 SOURCE_REPO_MABS=https://github.com/m-ab-s/media-autobuild_suite.git
 SOURCE_REPO_MEDIAINFO=https://github.com/MediaArea/MediaInfo.git
+SOURCE_REPO_MINIZIPNG=https://github.com/zlib-ng/minizip-ng.git
 SOURCE_REPO_MPV=https://github.com/mpv-player/mpv.git#tag=v0.36.0
 SOURCE_REPO_MUJS=https://github.com/ccxvii/mujs.git
 SOURCE_REPO_NEON=https://github.com/notroj/neon.git
@@ -121,4 +122,9 @@ SOURCE_REPO_XEVE=https://github.com/mpeg5/xeve.git
 SOURCE_REPO_XVC=https://github.com/divideon/xvc.git
 SOURCE_REPO_XVID=https://github.com/m-ab-s/xvid.git
 SOURCE_REPO_ZIMG=https://github.com/sekrit-twc/zimg.git
+SOURCE_REPO_ZLIB=https://github.com/madler/zlib.git
+SOURCE_REPO_ZLIBCHROMIUM=https://chromium.googlesource.com/chromium/src/third_party/zlib
+SOURCE_REPO_ZLIBCLOUDFLARE=https://github.com/cloudflare/zlib.git
+SOURCE_REPO_ZLIBNG=https://github.com/zlib-ng/zlib-ng.git
+SOURCE_REPO_ZLIBRS=https://github.com/trifectatechfoundation/zlib-rs.git
 SOURCE_REPO_ZVBI=https://github.com/zapping-vbi/zvbi.git

--- a/doc/forcing-recompilations.md
+++ b/doc/forcing-recompilations.md
@@ -95,6 +95,7 @@ Most libs use pkg-config files to check if they exist, so for most libs in this 
     xavs2
     xvc
     zimg
+    zlib
     zvbi-0.2 (libzvbi)
 
 ## Libraries not using pkg-config
@@ -150,6 +151,9 @@ To recompile these, delete `<appname>.exe` in corresponding binary directories:
         jo
         jq
         luajit
+        minigzip
+        miniunzip
+        minizip
         mujs
         openssl
         psl

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -146,7 +146,7 @@ set iniOptions=arch license2 vpx2 x2643 x2652 other265 flac fdkaac mediainfo ^
 soxB ffmpegB2 ffmpegUpdate ffmpegChoice mp4box rtmpdump mplayer2 mpv cores deleteSource ^
 strip pack logging bmx standalone updateSuite av1an aom faac exhale ffmbc curl cyanrip2 ^
 rav1e ripgrep dav1d libavif libheif vvc uvg266 jq dssim gifski avs2 dovitool hdr10plustool timeStamp ^
-noMintty ccache svthevc svtav1 svtvp9 xvc jo vlc CC jpegxl vvenc vvdec ffmpegPath pkgUpdateTime
+noMintty ccache svthevc svtav1 svtvp9 xvc jo vlc CC jpegxl vvenc vvdec zlib ffmpegPath pkgUpdateTime
 @rem re-add autouploadlogs if we find some way to upload to github directly instead
 
 set deleteIni=0
@@ -1381,6 +1381,36 @@ if %buildhdr10plustool%==2 set "hdr10plustool=n"
 if %buildhdr10plustool% GTR 2 GOTO hdr10plustool
 if %deleteINI%==1 echo.hdr10plustool=^%buildhdr10plustool%>>%ini%
 
+:zlib
+if [0]==[%zlibINI%] (
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    echo.
+    echo. Build zlib?
+    echo. 1 = Yes, build zlib
+    echo. 2 = Yes, build zlib (Chromium fork^)
+    echo. 3 = Yes, build zlib (Cloudflare fork^)
+    echo. 4 = Yes, build zlib-ng
+    echo. 5 = Yes, build zlib-rs
+    echo. 6 = No, use msys2 package when needed [Recommended]
+    echo.
+    echo. If "standalone=y", then minizip will be built alongside zlib.
+    echo.
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    set /P buildzlib="Build zlib: "
+) else set buildzlib=%zlibINI%
+
+if "%buildzlib%"=="" GOTO zlib
+if %buildzlib%==1 set "zlib=y"
+if %buildzlib%==2 set "zlib=chromium"
+if %buildzlib%==3 set "zlib=cloudflare"
+if %buildzlib%==4 set "zlib=ng"
+if %buildzlib%==5 set "zlib=rs"
+if %buildzlib%==6 set "zlib=n"
+if %buildzlib% GTR 6 GOTO zlib
+if %deleteINI%==1 echo.zlib=^%buildzlib%>>%ini%
+
 :CC
 if [0]==[%CCINI%] (
     echo -------------------------------------------------------------------------------
@@ -1954,7 +1984,7 @@ set compileArgs=--cpuCount=%cpuCount% --build32=%build32% --build64=%build64% ^
 --vvc=%vvc% --uvg266=%uvg266% --vvenc=%vvenc% --vvdec=%vvdec% --jq=%jq% --jo=%jo% --dssim=%dssim% ^
 --gifski=%gifski% --avs2=%avs2% --dovitool=%dovitool% --hdr10plustool=%hdr10plustool% --timeStamp=%timeStamp% ^
 --noMintty=%noMintty% --ccache=%ccache% --svthevc=%svthevc% --svtav1=%svtav1% --svtvp9=%svtvp9% ^
---xvc=%xvc% --vlc=%vlc% --libavif=%libavif% --libheif=%libheif% --jpegxl=%jpegxl% --av1an=%av1an% ^
+--xvc=%xvc% --vlc=%vlc% --libavif=%libavif% --libheif=%libheif% --jpegxl=%jpegxl% --av1an=%av1an% --zlib=%zlib% ^
 --ffmpegPath=%ffmpegPath% --exitearly=%MABS_EXIT_EARLY%
     @REM --autouploadlogs=%autouploadlogs%
     set "noMintty=%noMintty%"


### PR DESCRIPTION
Adds the option to compile zlib along with a selection of forks compatible with zlib's API (zlib-chromium, zlib-cloudflare, and zlib-ng).

I didn't take the approach of installing zlib-ng as an msys2 package [like I had suggested a few months ago](https://github.com/m-ab-s/media-autobuild_suite/issues/2812#issue-2760276465) because I didn't feel like waiting for it to be added much longer. I also tried adding zlib-rs too, but after building (what I think was) a valid zlib-API compatible library I got this error trying to link it with ffmpeg (I may try adding zlib-rs at a later date, so this is just here for my own reference):
```
ccache gcc -D_ISOC11_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DWIN32_LEAN_AND_MEAN -U__STRICT_ANSI__ -D__USE_MINGW_ANSI_STDIO=1 -D__printf__=__gnu_printf__ -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -pipe -D__USE_MINGW_ANSI_STDIO=1 -mthreads -Wno-int-conversion -std=c17 -fomit-frame-pointer -g -Wdeclaration-after-statement -Wall -Wdisabled-optimization -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wtype-limits -Wundef -Wmissing-prototypes -Wstrict-prototypes -Wempty-body -Wno-parentheses -Wno-switch -Wno-format-zero-length -Wno-pointer-sign -Wno-unused-const-variable -Wno-bool-operation -Wno-char-subscripts -O3 -fno-math-errno -fno-signed-zeros -fno-tree-vectorize -Werror=format-security -Werror=implicit-function-declaration -Werror=missing-prototypes -Werror=return-type -Werror=vla -Wformat -fdiagnostics-color=auto -Wmaybe-uninitialized -c -o /tmp/ffconf.Y7bFUbHS/test.o /tmp/ffconf.Y7bFUbHS/test.c
ar rcD /tmp/ffconf.Y7bFUbHS/test.a @/dev/null
check_builtin stdbit stdbit.h assert.h static_assert(__STDC_VERSION_STDBIT_H__ >= 202311L, "Compiler lacks stdbit.h")
test_code ld stdbit.h assert.h static_assert(__STDC_VERSION_STDBIT_H__ >= 202311L, "Compiler lacks stdbit.h") cc
test_ld cc
test_cc
BEGIN /tmp/ffconf.Y7bFUbHS/test.c
    1	#include <stdbit.h>
    2	#include <assert.h>
    3	int main(void) { static_assert(__STDC_VERSION_STDBIT_H__ >= 202311L, "Compiler lacks stdbit.h"); return 0; }
END /tmp/ffconf.Y7bFUbHS/test.c
ccache gcc -D_ISOC11_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DWIN32_LEAN_AND_MEAN -U__STRICT_ANSI__ -D__USE_MINGW_ANSI_STDIO=1 -D__printf__=__gnu_printf__ -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -pipe -D__USE_MINGW_ANSI_STDIO=1 -mthreads -Wno-int-conversion -std=c17 -fomit-frame-pointer -g -Wdeclaration-after-statement -Wall -Wdisabled-optimization -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wtype-limits -Wundef -Wmissing-prototypes -Wstrict-prototypes -Wempty-body -Wno-parentheses -Wno-switch -Wno-format-zero-length -Wno-pointer-sign -Wno-unused-const-variable -Wno-bool-operation -Wno-char-subscripts -O3 -fno-math-errno -fno-signed-zeros -fno-tree-vectorize -Werror=format-security -Werror=implicit-function-declaration -Werror=missing-prototypes -Werror=return-type -Werror=vla -Wformat -fdiagnostics-color=auto -Wno-maybe-uninitialized -c -o /tmp/ffconf.Y7bFUbHS/test.o /tmp/ffconf.Y7bFUbHS/test.c
C:/mabszlib/msys64/tmp/ffconf.Y7bFUbHS/test.c:1:10: fatal error: stdbit.h: No such file or directory
    1 | #include <stdbit.h>
      |          ^~~~~~~~~~
compilation terminated.
ERROR: zlib requested but not found
```