### PR TITLE
Minimum CMake version 3.5 into media-suite_helper.sh:do_cmake() and media-suite_compile.sh:do_x265_cmake()

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1870,6 +1870,7 @@ if [[ ! $x265 = n ]] && do_vcs "$SOURCE_REPO_X265"; then
         do_print_progress "Building $1" && shift 1
         extra_script pre cmake
         log "cmake" cmake "$(get_first_subdir -f)/source" -G Ninja \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -DCMAKE_INSTALL_PREFIX="$LOCALDESTDIR" -DBIN_INSTALL_DIR="$LOCALDESTDIR/bin-video" \
         -DENABLE_SHARED=OFF -DENABLE_CLI=OFF -DHIGH_BIT_DEPTH=ON \
         -DENABLE_HDR10_PLUS=ON $xpsupport -DCMAKE_CXX_COMPILER="$LOCALDESTDIR/bin/${CXX#ccache }.bat" \

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1340,6 +1340,7 @@ do_cmake() {
         return
     # shellcheck disable=SC2086
     log "cmake" cmake "$root" -G Ninja -DBUILD_SHARED_LIBS=off \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -DPython3_EXECUTABLE="${MINGW_PREFIX}/bin/python.exe" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
         -DCMAKE_TOOLCHAIN_FILE="$LOCALDESTDIR/etc/toolchain.cmake" \


### PR DESCRIPTION
(Possibly temporary?) fix for https://github.com/m-ab-s/media-autobuild_suite/issues/2870