### PR TITLE
suite: revert adding -liconv to link flags, enable iconv in fontconfig

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -409,14 +409,12 @@ if [[ $mplayer = y || $mpv = y ]] ||
         extracommands=()
         [[ $standalone = y ]] || extracommands+=(-Dtools=disabled)
         [[ $ffmpeg = sharedlibs ]] && extracommands+=(--default-both-libraries=both)
-        do_mesoninstall global -Ddoc=disabled -Dtests=disabled "${extracommands[@]}"
+        do_mesoninstall global -D{doc,tests}=disabled -Diconv=enabled "${extracommands[@]}"
         do_checkIfExist
         unset extracommands
     fi
     # Prevents ffmpeg from trying to link to a broken libfontconfig.dll.a
     [[ $ffmpeg = sharedlibs ]] || do_uninstall bin-global/libfontconfig-1.dll libfontconfig.dll.a
-
-    grep_or_sed iconv "$LOCALDESTDIR/lib/pkgconfig/fontconfig.pc" 's/Libs:.*/& -liconv/'
 
     _deps=(libfreetype.a)
     _check=(libharfbuzz.a harfbuzz.pc)

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -2075,8 +2075,7 @@ goto :EOF
     echo.CFLAGS+=" -mtune=generic -O2 -pipe" # performance related flags
     echo.CFLAGS+=" -D__USE_MINGW_ANSI_STDIO=1" # mingw-w64 specific flags for c99 printf
     echo.CXXFLAGS="${CFLAGS}" # copy CFLAGS to CXXFLAGS
-    echo.LDFLAGS="${CFLAGS} -static-libgcc -liconv" # copy CFLAGS to LDFLAGS
-    echo.RUSTFLAGS="-Clink-arg=-liconv"
+    echo.LDFLAGS="${CFLAGS} -static-libgcc" # copy CFLAGS to LDFLAGS
     echo.case "$CC" in
     echo.*clang^)
     echo.    # clang complains about using static-libstdc++ with C files.
@@ -2091,7 +2090,7 @@ goto :EOF
     echo.;;
     echo.esac
     echo.# CPPFLAGS used to be here, but cmake ignores it, so it's not as useful.
-    echo.export DXSDK_DIR ACLOCAL_PATH PKG_CONFIG PKG_CONFIG_PATH CFLAGS CXXFLAGS LDFLAGS RUSTFLAGS
+    echo.export DXSDK_DIR ACLOCAL_PATH PKG_CONFIG PKG_CONFIG_PATH CFLAGS CXXFLAGS LDFLAGS
     echo.
     echo.export CARGO_HOME="/opt/cargo"
     echo.if [[ -z "$CCACHE_DIR" ]]; then


### PR DESCRIPTION
Tested compilation without `-liconv` in `LDFLAGS`, and it appears only fontconfig has an issue with the library not being linked. Since fontconfig needs iconv during link time whether or not the feature is enabled, I decided to just add `-Diconv=enabled` so iconv would automatically link and get added to the .pc file.