### PR TITLE
Add heif-view.exe to _check

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2574,7 +2574,7 @@ if [[ $libheif != n ]] &&
     do_checkIfExist
 fi
 
-_check=(bin-video/heif-{dec,enc,info,thumbnailer}.exe)
+_check=(bin-video/heif-{dec,enc,info,thumbnailer,view}.exe)
 [[ $libheif = shared ]] && _check+=(bin-video/libheif.dll)
 if [[ $libheif != n ]] &&
     do_vcs "$SOURCE_REPO_LIBHEIF"; then


### PR DESCRIPTION
heif-view.exe was added in https://github.com/strukturag/libheif/commit/e20d44e7c10607965f1d754746ae8993bd1e3534

<!--
Description

(Optional) Fixes #[issueNumber]
--->
