### PR TITLE
Disable (legacy) jpegli inside libjxl

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -675,16 +675,16 @@ if [[ $jpegxl = y ]] || { [[ $ffmpeg != no ]] && enabled libjxl; }; then
     do_pacman_install brotli lcms2
     _deps=(libgflags.a)
     _check=(libjxl{{,_threads}.a,.pc} jxl/decode.h)
-    [[ $jpegxl = y ]] && _check+=(bin-global/{{c,d}jxl,{c,d}jpegli,jxlinfo}.exe)
+    [[ $jpegxl = y ]] && _check+=(bin-global/{{c,d}jxl,jxlinfo}.exe)
     if do_vcs "$SOURCE_REPO_LIBJXL"; then
         do_git_submodule
         do_patch "https://raw.githubusercontent.com/m-ab-s/mabs-patches/master/libjxl/0001-brotli-link-enc-before-common.patch" am
-        do_uninstall "${_check[@]}" include/jxl
+        do_uninstall "${_check[@]}" include/jxl bin-global/cjpegli.exe bin-global/djpegli.exe 
         do_pacman_install asciidoc
         extracommands=()
         [[ $jpegxl = y ]] || extracommands=("-DJPEGXL_ENABLE_TOOLS=OFF")
         CXXFLAGS+=" -DJXL_CMS_STATIC_DEFINE -DJXL_STATIC_DEFINE -DJXL_THREADS_STATIC_DEFINE" \
-            do_cmakeinstall global -D{BUILD_TESTING,JPEGXL_ENABLE_{BENCHMARK,DOXYGEN,MANPAGES,OPENEXR,SKCMS,EXAMPLES}}=OFF \
+            do_cmakeinstall global -D{BUILD_TESTING,JPEGXL_ENABLE_{BENCHMARK,DOXYGEN,MANPAGES,OPENEXR,SKCMS,EXAMPLES,JPEGLI}}=OFF \
             -DJPEGXL_{FORCE_SYSTEM_{BROTLI,LCMS2},STATIC}=ON "${extracommands[@]}"
         do_checkIfExist
         unset extracommands


### PR DESCRIPTION
The jpegli source has been branched from libjxl - according to the libjxl CMakeLists.txt, the default is libjpeg-turbo from the third_party subrepo (which is pulled by mabs).

I've used -DJPEGXL_ENABLE_JPEGLI=OFF in a libjxl_extra.sh for quite some time, but always had to remove the tools check for cjpegli/djpegli from media-suite_compile.sh

Moving jpegli completely outside libjxl and using a dependency seems to have stalled, but nevertheless jpegli development doesn't happen inside libjxl anymore. If the jpegli tools should be a built-in feature of mabs (probably not), it should be separate and use https://github.com/google/jpegli

If mabs should require a jpeg lib in local, it should be separate from the legacy 'just happens to be there' jpegli inside libjxl, too.