### PR TITLE
Fix typo (CFLGAS -> CFLAGS)

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2860,7 +2860,7 @@ if [[ $mpv != n ]] && pc_exists libavcodec libavformat libswscale libavfilter; t
         [[ -f mpv_extra.sh ]] && source mpv_extra.sh
 
         mapfile -t MPV_ARGS < <(mpv_build_args)
-        CFLGAS+=" ${mpv_cflags[*]}" LDFLAGS+=" ${mpv_ldflags[*]}" \
+        CFLAGS+=" ${mpv_cflags[*]}" LDFLAGS+=" ${mpv_ldflags[*]}" \
             do_mesoninstall video "${MPV_ARGS[@]}"
         unset MPV_ARGS mpv_cflags mpv_ldflags
         hide_conflicting_libs -R


### PR DESCRIPTION
Correct a typo in media_suite_compile.sh.