### PR TITLE
Add support for AudioToolbox via AudioToolboxWrapper

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1182,26 +1182,30 @@ if [[ $ffmpeg != no ]] && enabled liblc3 &&
     do_checkIfExist
 fi
 
-_check=(bin/atw_ldwrapper libAudioToolboxWrapper.a
-    bin-video/{ASL,CoreAudioToolbox,CoreFoundation,icudt62,libdispatch,libicuin,libicuuc,objc}.dll)
-if [[ $ffmpeg != no ]] && enabled audiotoolbox &&
-    do_vcs "$SOURCE_REPO_AUDIOTOOLBOX"; then
+_check=(bin/atw_ldwrapper libAudioToolboxWrapper.a)
+if [[ $ffmpeg != no ]] && enabled audiotoolbox; then
     _qtfiles_url="https://github.com/AnimMouse/QTFiles/releases/download/v12.10.11"
-    do_uninstall "${_check[@]}"
-    if [[ $build64 = yes ]]; then
-        do_wget -r -q -h 32fcd058936410f7eabd3b55a8931bce5f45bb7892d6a2c65387820daca52f58 \
-            "${_qtfiles_url}/QTfiles64.7z" QTfiles64.7z
-        do_install QTfiles64/*.dll bin-video
-        rm -rf QTfiles64/ QTfiles64.7z
+    _deps=(bin-video/{ASL,CoreAudioToolbox,CoreFoundation,icudt62,libdispatch,libicuin,libicuuc,objc}.dll)
+    if ! files_exist "${_deps[@]}"; then
+        if [[ $build64 = yes ]]; then
+            do_wget -r -q -h 32fcd058936410f7eabd3b55a8931bce5f45bb7892d6a2c65387820daca52f58 \
+                "${_qtfiles_url}/QTfiles64.7z"
+            do_install *.dll bin-video
+            rm -rf ../QTfiles64/
+        fi
+        if [[ $build32 = yes ]]; then
+            do_wget -r -q -h c6c582fe1af4e0c2b1eb7c141ad929a81f14d123aedd3b16df8226c104fb3028 \
+                "${_qtfiles_url}/QTfiles.7z"
+            do_install *.dll bin-video
+            rm -rf ../QTfiles/
+        fi
     fi
-    if [[ $build32 = yes ]]; then
-        do_wget -r -q -h c6c582fe1af4e0c2b1eb7c141ad929a81f14d123aedd3b16df8226c104fb3028 \
-            "${_qtfiles_url}/QTfiles.7z" QTfiles.7z
-        do_install QTfiles/*.dll bin-video
-        rm -rf QTfiles/ QTfiles.7z
+
+    if do_vcs "$SOURCE_REPO_AUDIOTOOLBOX"; then
+        do_uninstall "${_check[@]}"
+        do_cmakeinstall
+        do_checkIfExist
     fi
-    do_cmakeinstall
-    do_checkIfExist
     unset _qtfiles_url
 fi
 

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1189,18 +1189,20 @@ if [[ $ffmpeg != no ]] && enabled audiotoolbox &&
     _qtfiles_url="https://github.com/AnimMouse/QTFiles/releases/download/v12.10.11"
     do_uninstall "${_check[@]}"
     if [[ $build64 = yes ]]; then
-        do_wget -c -r -q "${_qtfiles_url}/QTfiles64.7z" QTfiles64.7z
+        do_wget -r -q -h 32fcd058936410f7eabd3b55a8931bce5f45bb7892d6a2c65387820daca52f58 \
+            "${_qtfiles_url}/QTfiles64.7z" QTfiles64.7z
         do_install QTfiles64/*.dll bin-video
         rm -rf QTfiles64/ QTfiles64.7z
     fi
     if [[ $build32 = yes ]]; then
-        do_wget -c -r -q "${_qtfiles_url}/QTfiles.7z" QTfiles.7z
+        do_wget -r -q -h c6c582fe1af4e0c2b1eb7c141ad929a81f14d123aedd3b16df8226c104fb3028 \
+            "${_qtfiles_url}/QTfiles.7z" QTfiles.7z
         do_install QTfiles/*.dll bin-video
         rm -rf QTfiles/ QTfiles.7z
     fi
     do_cmakeinstall
     do_checkIfExist
-    unset _ver _qtfiles_url
+    unset _qtfiles_url
 fi
 
 if [[ $exitearly = EE4 ]]; then
@@ -2488,7 +2490,7 @@ if [[ $ffmpeg != no ]]; then
 
         # Bypass ffmpeg check for audiotoolbox
         enabled audiotoolbox && do_addOption --extra-libs=-lAudioToolboxWrapper && do_addOption --disable-outdev=audiotoolbox &&
-            sed -ri "s/check_apple_framework AudioToolbox/check_apple_framework/g" /build/ffmpeg-git/configure
+            sed -ri "s/check_apple_framework AudioToolbox/check_apple_framework/g" configure
 
         if enabled openal &&
             pc_exists "openal"; then

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -4,6 +4,7 @@
 SOURCE_REPO_AMF=https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git
 SOURCE_REPO_ANGLE=https://chromium.googlesource.com/angle/angle
 SOURCE_REPO_ARRIB24=https://github.com/nkoriyama/aribb24.git
+SOURCE_REPO_AUDIOTOOLBOX=https://github.com/cynagenautes/AudioToolboxWrapper.git
 SOURCE_REPO_AV1AN=https://github.com/master-of-zen/Av1an.git
 SOURCE_REPO_AVISYNTH=https://github.com/AviSynth/AviSynthPlus.git
 SOURCE_REPO_CODEC2=https://github.com/drowe67/codec2.git

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -125,7 +125,7 @@ set ffmpeg_options_full=chromaprint decklink frei0r libaribb24 libbs2b libcaca ^
 libcdio libflite libfribidi libgme libilbc libsvthevc ^
 libsvtvp9 libkvazaar libmodplug librist librtmp librubberband #libssh ^
 libtesseract libxavs libzmq libzvbi openal libcodec2 ladspa #vapoursynth #liblensfun ^
-libglslang vulkan libdavs2 libxavs2 libuavs3d libplacebo libjxl libvvenc libvvdec liblc3
+libglslang vulkan libdavs2 libxavs2 libuavs3d libplacebo libjxl libvvenc libvvdec liblc3 audiotoolbox
 
 :: options also available with the suite that add shared dependencies
 set ffmpeg_options_full_shared=opencl opengl cuda-nvcc libnpp libopenh264


### PR DESCRIPTION
Sed code is based of  [M05QU170](https://github.com/user-attachments/files/19558379/media-suite_compile-audiotoolbox.patch) patch.

I'm not really sure if this is the right way to do this....
Also current implementation might not [decode probably](https://github.com/AnimMouse/QTFiles/tree/v12.10.11?tab=readme-ov-file#icudt62dll-dummy-file), though my limited testing show no difference between the original `icudt62.dll` and the dummy one.