### PR TITLE
Fix gifski, zlib-chromium (clang), and partially fix av1an

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -328,7 +328,7 @@ if [[ $gifski != n ]]; then
             do_pacman_install clang
         fi
         PKG_CONFIG="$LOCALDESTDIR/bin/ab-pkg-config-static.bat" \
-            do_rust "${extracommands[@]}"
+            LIBCLANG_PATH="$MINGW_PREFIX/bin" do_rust "${extracommands[@]}"
         do_install "target/$CARCH-pc-windows-gnu$rust_target_suffix/release/gifski.exe" bin-global/
         do_checkIfExist
         unset extracommands
@@ -2141,7 +2141,7 @@ if [[ $av1an != n ]]; then
         do_uninstall "${_check[@]}"
         do_pacman_install clang
         PKG_CONFIG="$LOCALDESTDIR/bin/ab-pkg-config-static.bat" \
-            VAPOURSYNTH_LIB_DIR="$LOCALDESTDIR/lib" do_rust
+            LIBCLANG_PATH="$MINGW_PREFIX/bin" VAPOURSYNTH_LIB_DIR="$LOCALDESTDIR/lib" do_rust
         do_install "target/$CARCH-pc-windows-gnu$rust_target_suffix/release/av1an.exe" $av1an_bindir/
         do_checkIfExist
     fi

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -189,13 +189,14 @@ else
             # these macros are for some reason not set, even though they should be according to CMakeLists.txt
             local zlib_macros="-DINFLATE_CHUNK_SIMD_SSE2 -DADLER32_SIMD_SSSE3 -DINFLATE_CHUNK_READ_64LE -DCRC32_SIMD_SSE42_PCLMUL -DDEFLATE_SLIDE_HASH_SSE2 -D_LARGEFILE64_SOURCE=1 -DX86_WINDOWS"
             sed -i 's; -L${sharedlibdir};;' zlib.pc.cmakein
-            # add missing header and source files needed for compilation, and force all executables to link with static zlib
+            # add missing header and source files needed for compilation, force all executables to link with static zlib, and name libraries correctly with -DUNIX=OFF
             sed -e 's;ioapi.h;ioapi.h contrib/minizip/iowin32.c contrib/minizip/iowin32.h;' \
-                -e 's;zlib);zlibstatic);' -i CMakeLists.txt
+                -e 's;zlib);zlibstatic);' -e 's;BUILD_SHARED_LIBS AND WIN32;MINGW;' \
+                -e 's;zlib PROPERTIES SUFFIX "1.dll";zlib zlibstatic PROPERTIES OUTPUT_NAME z;' -i CMakeLists.txt
             # the win32 dir is missing, so copy the folder from original zlib
             do_wget -c -r -q "https://github.com/madler/zlib/archive/refs/heads/develop.tar.gz"
             tar --strip-components=1 -xzf develop.tar.gz zlib-develop/win32
-            do_cmakeinstall -DINSTALL_PKGCONFIG_DIR="${LOCALDESTDIR}/lib/pkgconfig" \
+            do_cmakeinstall -DUNIX=OFF -DINSTALL_PKGCONFIG_DIR="${LOCALDESTDIR}/lib/pkgconfig" \
                 -DUSE_ZLIB_RABIN_KARP_HASH=ON -DENABLE_SIMD_OPTIMIZATIONS=ON \
                 -DCMAKE_C_FLAGS="${CFLAGS} ${zlib_macros} -msse4.2 -mpclmul" "${extracommands[@]}"
             [[ $standalone = y ]] && do_install minizip_bin.exe bin-global/minizip.exe &&


### PR DESCRIPTION
Fixes https://github.com/m-ab-s/media-autobuild_suite/issues/2926 and partially addresses https://github.com/m-ab-s/media-autobuild_suite/issues/2922 and https://github.com/m-ab-s/media-autobuild_suite/issues/2927 (only the undefined LIBCLANG_PATH error, not the missing advapi32 symbols error)