### PR TITLE
aom: add patch to disable building extra executables

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1301,7 +1301,8 @@ _check=(libaom.a aom.pc)
 if { [[ $aom = y ]] || [[ $libavif = y ]] || { [[ $ffmpeg != no ]] && enabled libaom; }; } &&
     do_vcs "$SOURCE_REPO_LIBAOM"; then
     do_pacman_install yasm
-    extracommands=()
+    do_patch "https://raw.githubusercontent.com/m-ab-s/mabs-patches/master/aom/0001-CMake-Add-ENABLE_EXTRA_EXAMPLES.patch" am
+    extracommands=("-DENABLE_EXTRA_EXAMPLES=off")
     if [[ $aom = y || $standalone = y || $av1an != n ]]; then
         # fix google's shit
         sed -ri 's;_PREFIX.+CMAKE_INSTALL_BINDIR;_FULL_BINDIR;' \


### PR DESCRIPTION
Adds a patch for aom to disable building extra executables not installed by default (anything not aomdec/aomenc), which saves ~175MB and reduces build times

Patch is in [this pull request](https://github.com/m-ab-s/mabs-patches/pull/8)

<img width="750" height="502" alt="{4B407B48-F437-4A34-B229-27E22E8629D9}" src="https://github.com/user-attachments/assets/f301f2df-3088-4893-bba3-8852fb231705" />
