### PR TITLE
Remove obsolete artifact in glslang check.

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2296,7 +2296,7 @@ if { [[ $mpv != n ]] ||
     do_checkIfExist
 fi
 
-_check=(lib{glslang,OSDependent,SPVRemapper}.a
+_check=(lib{glslang,OSDependent}.a
         libSPIRV{,-Tools{,-opt,-link,-reduce}}.a glslang/SPIRV/GlslangToSpv.h)
 if { [[ $mpv != n ]] ||
      { [[ $ffmpeg != no ]] && enabled_any libplacebo libglslang; } } &&


### PR DESCRIPTION
glslang no longer builds libSPVRemapper as a separate object as of https://github.com/KhronosGroup/glslang/commit/e70645c4571fb5136f2fb3f27f25daff2b83cfa6.