### PR TITLE
Patch all providers in fix_impsyms

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1940,7 +1940,6 @@ fix_impsyms() (
         for path in "${search_paths[@]}"; do
             if [[ -f "$path/lib${name}.a" ]]; then
                 provider_paths+=("$path/lib${name}.a")
-                break
             fi
         done
     done


### PR DESCRIPTION
The user may have residual and differing versions of a library and we can't always predict which version a package may use. So patch all found providers.

The proper fix is to run pkg config on all entries in Libs and identify specific location of each entry.

<!--
Description

(Optional) Fixes #[issueNumber]
--->
