### PR TITLE
ffmpeg: fix patch conflict between svt-vp9 and vvdec

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2554,10 +2554,6 @@ if [[ $ffmpeg != no ]]; then
         ff_base_commit=$(git rev-parse HEAD)
         do_changeFFmpegConfig "$license"
         [[ -f ffmpeg_extra.sh ]] && source ffmpeg_extra.sh
-        if enabled libvvdec; then
-            do_patch "https://raw.githubusercontent.com/wiki/fraunhoferhhi/vvdec/data/patch/v9-libvvdec.patch"  ||
-                do_removeOptions --enable-libvvdec
-        fi
         if enabled libsvthevc; then
             do_patch "https://raw.githubusercontent.com/1480c1/SVT-HEVC/master/ffmpeg_plugin/master-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch" am ||
                 do_removeOption --enable-libsvthevc
@@ -2565,6 +2561,10 @@ if [[ $ffmpeg != no ]]; then
         if enabled libsvtvp9; then
             do_patch "https://raw.githubusercontent.com/1480c1/SVT-VP9/master/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch" am ||
                 do_removeOption --enable-libsvtvp9
+        fi
+        if enabled libvvdec; then
+            do_patch "https://raw.githubusercontent.com/wiki/fraunhoferhhi/vvdec/data/patch/v9-libvvdec.patch"  ||
+                do_removeOptions --enable-libvvdec
         fi
 
         enabled libsvthevc || do_removeOption FFMPEG_OPTS_SHARED "--enable-libsvthevc"


### PR DESCRIPTION
<!--
Description

(Optional) Fixes #[issueNumber]
--->
`git am` is stricter about patch context than regular `patch`. Applying diff-based patches (`libvvdec`) first can cause later `git am` (`svt-vp9`) steps to fail, so reorder the build script to apply `git am` patches before regular patches.
Fixes #3141 
By the way, maybe the `do_patch` function need some improvements to prevent this kind of confusing problem.