### PR TITLE
Add multiple build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For information about the compiler environment see the wiki, there you also have
         - librist (git)
         - librtmp (git)
         - librubberband (git)
-        - libssh (broken)
+        - libssh (mingw-w64)
         - libsvthevc (git) (using non-upstream patch)
         - libsvtvp9 (git) (using non-upstream patch)
         - libtesseract (git)

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1298,6 +1298,11 @@ if [[ $ffmpeg != no ]] && enabled libmpeghdec &&
         extracommands=(-Dmpeghdec_BUILD_BINARIES=OFF -Dmpeghdec_BUILD_UIMANAGER=OFF)
     fi
     do_cmakeinstall "${extracommands[@]}" -DCMAKE_INSTALL_DATAROOTDIR=lib
+    # Avoid bundled FDK symbol collisions with libfdk-aac.
+    if enabled libfdk-aac; then
+        prefix_archive_symbols "$LOCALDESTDIR/lib/libmpeghdec.a" \
+            mpeghdec_private_ '^_?(mpeghdecoder_|mpegh_UI_)'
+    fi
     [[ $standalone = y ]] &&
         do_install bin/{mpeghDecoder,mpeghUiManager}.exe bin-audio/
     sed -i 's/^Cflags:.*/& -DMPEGHDEC_STATIC/' "$LOCALDESTDIR/lib/pkgconfig/mpeghdec.pc"

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1643,7 +1643,7 @@ _check=(libxavs2.a xavs2_config.h xavs2.{h,pc})
 [[ $standalone = y ]] && _check+=(bin-video/xavs2.exe)
 if [[ $bits = 32bit ]]; then
     do_removeOption --enable-libxavs2
-elif { [[ $avs2 = y ]] || { [[ $ffmpeg != no ]] && enabled libxavs2; }; } &&
+elif { [[ $avs2 != n ]] || { [[ $ffmpeg != no ]] && enabled libxavs2; }; } &&
     do_vcs "$SOURCE_REPO_XAVS2"; then
     do_patch "https://github.com/pkuvcl/xavs2/compare/master...1480c1:xavs2:gcc14/pointerconversion.patch" am
     cd_safe build/linux
@@ -1656,17 +1656,24 @@ fi
 
 _check=(libdavs2.a davs2_config.h davs2.{h,pc})
 [[ $standalone = y ]] && _check+=(bin-video/davs2.exe)
+davs2_repo=$SOURCE_REPO_DAVS
+extracommands=()
+if [[ $avs2 = 10bit ]]; then
+    davs2_repo=$SOURCE_REPO_DAVS10bit
+    extracommands+=(--bit-depth=10)
+fi
 if [[ $bits = 32bit ]]; then
     do_removeOption --enable-libdavs2
-elif { [[ $avs2 = y ]] || { [[ $ffmpeg != no ]] && enabled libdavs2; }; } &&
-    do_vcs "$SOURCE_REPO_DAVS"; then
+elif { [[ $avs2 != n ]] || { [[ $ffmpeg != no ]] && enabled libdavs2; }; } &&
+    do_vcs "$davs2_repo"; then
     cd_safe build/linux
     [[ -f config.mak ]] && log "distclean" make distclean
     do_uninstall all "${_check[@]}"
-    do_configure --bindir="$LOCALDESTDIR"/bin-video --enable-strip
+    do_configure --bindir="$LOCALDESTDIR"/bin-video --enable-strip "${extracommands[@]}"
     do_makeinstall
     do_checkIfExist
 fi
+unset davs2_repo extracommands
 
 _check=(libuavs3d.a uavs3d.{h,pc})
 [[ $standalone = y ]] && _check+=(bin-video/uavs3dec.exe)

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1289,9 +1289,6 @@ _check=(libmpeghdec.a mpeghdec.pc mpeghdec/{mpeghexport,mpeghdecoder}.h)
 if [[ $ffmpeg != no ]] && enabled libmpeghdec &&
     do_vcs "$SOURCE_REPO_MPEGHDEC"; then
     do_uninstall include/mpeghdec "${_check[@]}"
-    # Avoid duplicate SHORT overloads with MinGW's LLP64 data model.(Upstream issue)
-    grep_or_sed '__x86_64__) && !defined(_WIN32)' src/libFDK/include/common_fix.h \
-        's;!defined\(_MSC_VER\) && defined\(__x86_64__\);& \&\& !defined(_WIN32);'
     if [[ $standalone = y ]]; then
         extracommands=(-Dmpeghdec_BUILD_BINARIES=ON -Dmpeghdec_BUILD_UIMANAGER=ON)
     else

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2452,7 +2452,7 @@ if enabled libcdio || mpv_enabled cdda; then
 fi
 
 if [[ $ffmpeg != no ]]; then
-    do_pacman_install texinfo
+    do_pacman_install -m texinfo
     enabled libgsm && do_pacman_install gsm
     enabled libsnappy && do_pacman_install snappy
     if enabled libxvid && [[ $standalone = n ]]; then
@@ -2462,9 +2462,9 @@ if [[ $ffmpeg != no ]]; then
     fi
     if enabled libssh; then
         do_pacman_install libssh
-        do_addOption --extra-cflags=-DLIBSSH_STATIC "--extra-ldflags=-Wl,--allow-multiple-definition"
-        grep_or_sed "Requires.private" "$MINGW_PREFIX"/lib/pkgconfig/libssh.pc \
-            "/Libs:/ i\Requires.private: zlib libssl"
+        do_addOption --extra-cflags=-DLIBSSH_STATIC
+        grep_or_sed "Requires.private:.*libssl" "$MINGW_PREFIX"/lib/pkgconfig/libssh.pc \
+            $'/^Libs:/ i\\\nRequires.private: libssl libcrypto zlib\\\nLibs.private: -liphlpapi -lws2_32 -lpthread'
     fi
     enabled libtheora && do_pacman_install libtheora
     enabled libcaca && do_addOption --extra-cflags=-DCACA_STATIC && do_pacman_install libcaca

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1283,6 +1283,28 @@ if [[ $ffmpeg != no ]] && enabled liblc3 &&
     do_checkIfExist
 fi
 
+_check=(libmpeghdec.a mpeghdec.pc mpeghdec/{mpeghexport,mpeghdecoder}.h)
+[[ $standalone = y ]] && _check+=(mpeghdec/mpeghUIManager.h
+    bin-audio/{mpeghDecoder,mpeghUiManager}.exe)
+if [[ $ffmpeg != no ]] && enabled libmpeghdec &&
+    do_vcs "$SOURCE_REPO_MPEGHDEC"; then
+    do_uninstall include/mpeghdec "${_check[@]}"
+    # Avoid duplicate SHORT overloads with MinGW's LLP64 data model.(Upstream issue)
+    grep_or_sed '__x86_64__) && !defined(_WIN32)' src/libFDK/include/common_fix.h \
+        's;!defined\(_MSC_VER\) && defined\(__x86_64__\);& \&\& !defined(_WIN32);'
+    if [[ $standalone = y ]]; then
+        extracommands=(-Dmpeghdec_BUILD_BINARIES=ON -Dmpeghdec_BUILD_UIMANAGER=ON)
+    else
+        extracommands=(-Dmpeghdec_BUILD_BINARIES=OFF -Dmpeghdec_BUILD_UIMANAGER=OFF)
+    fi
+    do_cmakeinstall "${extracommands[@]}" -DCMAKE_INSTALL_DATAROOTDIR=lib
+    [[ $standalone = y ]] &&
+        do_install bin/{mpeghDecoder,mpeghUiManager}.exe bin-audio/
+    sed -i 's/^Cflags:.*/& -DMPEGHDEC_STATIC/' "$LOCALDESTDIR/lib/pkgconfig/mpeghdec.pc"
+    do_checkIfExist
+    unset extracommands
+fi
+
 _check=(bin/atw_ldwrapper libAudioToolboxWrapper.a)
 if [[ $ffmpeg != no ]] && enabled audiotoolbox; then
     _qtfiles_url="https://github.com/AnimMouse/QTFiles/releases/download/v12.10.11"

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -84,6 +84,7 @@ SOURCE_REPO_LUAJIT=https://github.com/LuaJIT/LuaJIT.git
 SOURCE_REPO_MABS=https://github.com/m-ab-s/media-autobuild_suite.git
 SOURCE_REPO_MEDIAINFO=https://github.com/MediaArea/MediaInfo.git
 SOURCE_REPO_MINIZIPNG=https://github.com/zlib-ng/minizip-ng.git
+SOURCE_REPO_MPEGHDEC=https://github.com/Fraunhofer-IIS/mpeghdec.git
 SOURCE_REPO_MPV=https://github.com/mpv-player/mpv.git
 SOURCE_REPO_MUJS=https://codeberg.org/ccxvii/mujs.git
 SOURCE_REPO_NEON=https://github.com/notroj/neon.git

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -12,6 +12,7 @@ SOURCE_REPO_CURL=https://github.com/curl/curl.git
 SOURCE_REPO_CYANRIP=https://github.com/cyanreg/cyanrip.git
 SOURCE_REPO_DAV1D=https://code.videolan.org/videolan/dav1d.git
 SOURCE_REPO_DAVS=https://github.com/pkuvcl/davs2.git
+SOURCE_REPO_DAVS10bit=https://github.com/saindriches/davs2.git
 SOURCE_REPO_DECKLINK=https://gitlab.com/m-ab-s/decklink-headers.git
 SOURCE_REPO_DLFCN=https://github.com/dlfcn-win32/dlfcn-win32.git
 SOURCE_REPO_DOVI_TOOL=https://github.com/quietvoid/dovi_tool.git

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -929,9 +929,9 @@ do_getFFmpegConfig() {
     fi
 
     if [[ $ffmpegKeepLegacyOpts == n ]]; then
-        enabled_any lib{vo-aacenc,aacplus,utvideo,dcadec,faac,ebur128,ndi_newtek,ndi-newtek,npp,ssh,wavpack} netcdf &&
-            do_removeOption "--enable-(lib(vo-aacenc|aacplus|utvideo|dcadec|faac|ebur128|ndi_newtek|ndi-newtek|npp|ssh|wavpack)|netcdf)" &&
-            sed -ri 's;--enable-(lib(vo-aacenc|aacplus|utvideo|dcadec|faac|ebur128|ndi_newtek|ndi-newtek|npp|ssh|wavpack)|netcdf);;g' \
+        enabled_any lib{vo-aacenc,aacplus,utvideo,dcadec,faac,ebur128,ndi_newtek,ndi-newtek,npp,wavpack} netcdf &&
+            do_removeOption "--enable-(lib(vo-aacenc|aacplus|utvideo|dcadec|faac|ebur128|ndi_newtek|ndi-newtek|npp|wavpack)|netcdf)" &&
+            sed -ri 's;--enable-(lib(vo-aacenc|aacplus|utvideo|dcadec|faac|ebur128|ndi_newtek|ndi-newtek|npp|wavpack)|netcdf);;g' \
                 "$LOCALBUILDDIR/ffmpeg_options.txt"
     fi
 }

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1898,6 +1898,93 @@ create_debug_link() {
     done
 }
 
+# Prefix internal strong symbols in a static archive without changing its public ABI.
+# preserve_regex is an AWK ERE tested against each full symbol name; matches stay unchanged.
+# Unsafe archive formats and target-name collisions fail without running objcopy.
+# prefix_archive_symbols archive symbol_prefix preserve_regex
+# Example: prefix_archive_symbols libfoo.a foo_private_ '^_?foo_'
+prefix_archive_symbols() (
+    set -o pipefail
+    local archive="$1" symbol_prefix="$2" preserve_regex="$3" archive_magic temp_dir
+    local symbol_map symbol_table section_table
+    [[ -f $archive && -n $symbol_prefix && -n $preserve_regex ]] || return 1
+    [[ $symbol_prefix != *[[:space:]]* ]] || return 1
+
+    # Thin archives reference external members, so an in-place rewrite is not self-contained.
+    archive_magic=$(head -c 7 "$archive") || return 1
+    if [[ $archive_magic != '!<arch>' ]]; then
+        printf 'prefix_archive_symbols: %s is not a regular archive\n' "$archive" >&2
+        return 1
+    fi
+
+    temp_dir=$(mktemp -d) || return 1
+    trap 'rm -rf "$temp_dir"' EXIT
+    symbol_map="$temp_dir/symbol-map"
+    symbol_table="$temp_dir/symbol-table"
+    section_table="$temp_dir/sections"
+
+    # Renaming the native symbol table does not update embedded GCC/LLVM LTO bytecode.
+    objdump -h "$archive" > "$section_table" || return 1
+    if grep -Eq '\.gnu\.lto_|\.llvmbc|\.llvmcmd' "$section_table"; then
+        printf 'prefix_archive_symbols: LTO archives are not supported: %s\n' "$archive" >&2
+        return 1
+    fi
+
+    # POSIX nm output supplies both names and types. Keep every row until END because
+    # a weak/import companion can appear after the ordinary-looking symbol it protects.
+    nm -P -g "$archive" > "$symbol_table" || return 1
+    awk -v preserve="$preserve_regex" -v prefix="$symbol_prefix" '
+        function protect(symbol) { protected[symbol] = 1 }
+        NF >= 2 && length($2) == 1 {
+            symbol = $1
+            type = $2
+            symbols[++count] = symbol
+            types[count] = type
+            # Include both definitions and references when checking generated names.
+            existing[symbol] = 1
+
+            # MinGW represents weak aliases as .weak.foo. + foo, and imports as
+            # __imp_foo + foo. Renaming only one half would break linker semantics.
+            if (symbol ~ /^\.weak\./) {
+                protect(symbol)
+                sub(/^\.weak\./, "", symbol)
+                sub(/\.$/, "", symbol)
+                protect(symbol)
+            } else if (symbol ~ /^__imp_/) {
+                protect(symbol)
+                sub(/^__imp_/, "", symbol)
+                protect(symbol)
+            } else if (type != "U" && type !~ /^[BDGRST]$/) {
+                protect(symbol)
+            }
+        }
+        END {
+            # Emit mappings only after the complete protection set is known.
+            for (i = 1; i <= count; i++) {
+                symbol = symbols[i]
+                type = types[i]
+                # U entries get rewritten by objcopy only when a matching definition
+                # produced a mapping. Other non-strong types stay untouched.
+                if (type == "U" || symbol in protected || type !~ /^[BDGRST]$/) continue
+                if (symbol ~ preserve || index(symbol, prefix) == 1) continue
+                target = prefix symbol
+                # Do not let a generated name capture an existing definition/reference.
+                if (target in existing) {
+                    printf "prefix_archive_symbols: target symbol already exists: %s\n", \
+                        target > "/dev/stderr"
+                    collision = 1
+                    continue
+                }
+                print symbol, target
+            }
+            exit collision
+        }' "$symbol_table" |
+        sort -u > "$symbol_map" ||
+        return 1
+    [[ -s $symbol_map ]] || return 0
+    objcopy --redefine-syms="$symbol_map" "$archive"
+)
+
 # do_dlltool lib.a a.def
 do_dlltool() (
     if dlltool --help | grep -q llvm; then

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1371,8 +1371,9 @@ if [0]==[%avs2INI%] (
     echo -------------------------------------------------------------------------------
     echo.
     echo. Build avs2 (Audio Video Coding Standard Gen2 encoder/decoder^)?
-    echo. 1 = Yes
+    echo. 1 = Yes (official davs2, 8-bit only^)
     echo. 2 = No
+    echo. 3 = Yes (unofficial davs2 fork with 10-bit support^)
     echo.
     echo. Binaries being built depends on "standalone=y" and are always static.
     echo.
@@ -1384,7 +1385,8 @@ if [0]==[%avs2INI%] (
 if "%buildavs2%"=="" GOTO avs2
 if %buildavs2%==1 set "avs2=y"
 if %buildavs2%==2 set "avs2=n"
-if %buildavs2% GTR 2 GOTO avs2
+if %buildavs2%==3 set "avs2=10bit"
+if %buildavs2% GTR 3 GOTO avs2
 if %deleteINI%==1 echo.avs2=^%buildavs2%>>%ini%
 
 :dovitool

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -143,7 +143,7 @@ set mpv_options_basic="-Dlua=luajit"
 set mpv_options_full=dvdnav cdda #egl-angle #html-build ^
 #pdf-build openal sdl2-gamepad sdl2-audio sdl2-video
 
-set iniOptions=arch targetPlatform license2 vpx2 x2643 x2652 other265 flac fdkaac mediainfo ^
+set iniOptions=arch license2 vpx2 x2643 x2652 other265 flac fdkaac mediainfo ^
 soxB ffmpegB2 ffmpegUpdate ffmpegChoice ffmpegKeepLegacyOpts mp4box rtmpdump mplayer2 mpv ^
 cores deleteSource strip pack logging bmx standalone updateSuite av1an aom faac exhale ffmbc ^
 curl cyanrip2 rav1e ripgrep dav1d libavif libheif vvc uvg266 jq dssim gifski avs2 dovitool ^
@@ -200,36 +200,6 @@ if %buildEnv%==2 set "build32=yes" && set "build64=no"
 if %buildEnv%==3 set "build32=no" && set "build64=yes"
 if %buildEnv% GTR 3 GOTO selectSystem
 if %deleteINI%==1 echo.arch=^%buildEnv%>>%ini%
-
-:targetPlatform
-if [0]==[%targetPlatformINI%] (
-    if %build64%==yes (
-        echo -------------------------------------------------------------------------------
-        echo -------------------------------------------------------------------------------
-        echo.
-        echo. Choose CPU requirement for 64-bit binaries:
-        echo. 1 = x86-64, baseline x64 [maximum compatibility]
-        echo. 2 = x86-64-v2, SSE4.2/POPCNT-capable CPUs
-        echo. 3 = x86-64-v3, AVX/AVX2-capable CPUs [recommended]
-        echo. 4 = x86-64-v4, AVX-512-capable CPUs, limited compatibility
-        echo. 5 = native, optimize for this CPU, not portable
-        echo.
-        echo. For "both", this only affects 64-bit builds; 32-bit stays generic.
-        echo.
-        echo -------------------------------------------------------------------------------
-        echo -------------------------------------------------------------------------------
-        set /P buildTargetPlatform="64-bit CPU target: "
-    ) else set "buildTargetPlatform=1"
-) else set buildTargetPlatform=%targetPlatformINI%
-
-if "%buildTargetPlatform%"=="" GOTO targetPlatform
-if %buildTargetPlatform%==1 set "targetPlatform=x86-64"
-if %buildTargetPlatform%==2 set "targetPlatform=x86-64-v2"
-if %buildTargetPlatform%==3 set "targetPlatform=x86-64-v3"
-if %buildTargetPlatform%==4 set "targetPlatform=x86-64-v4"
-if %buildTargetPlatform%==5 set "targetPlatform=native"
-if %buildTargetPlatform% GTR 5 GOTO targetPlatform
-if %deleteINI%==1 echo.targetPlatform=^%buildTargetPlatform%>>%ini%
 
 :ffmpeglicense
 if [0]==[%license2INI%] (
@@ -2085,8 +2055,6 @@ if not exist %instdir%\%1\share (
 goto :EOF
 
 :writeProfile
-set "profileMarchFlag= -march=%targetPlatform%"
-if %1==32 set "profileMarchFlag="
 (
     echo.#!/usr/bin/bash
     if %1==32 (
@@ -2132,7 +2100,7 @@ if %1==32 set "profileMarchFlag="
     echo.PKG_CONFIG_PATH="${LOCALDESTDIR}/lib/pkgconfig:${MINGW_PREFIX}/lib/pkgconfig"
     echo.
     echo.CFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong" # security related flags
-    echo.CFLAGS+=" -mtune=generic -O2 -pipe%profileMarchFlag%" # performance related flags
+    echo.CFLAGS+=" -mtune=generic -O2 -pipe" # performance related flags
     echo.CFLAGS+=" -D__USE_MINGW_ANSI_STDIO=1" # mingw-w64 specific flags for c99 printf
     echo.CXXFLAGS="${CFLAGS}" # copy CFLAGS to CXXFLAGS
     echo.LDFLAGS="${CFLAGS} -static-libgcc" # copy CFLAGS to LDFLAGS
@@ -2153,10 +2121,6 @@ if %1==32 set "profileMarchFlag="
     echo.export DXSDK_DIR ACLOCAL_PATH PKG_CONFIG PKG_CONFIG_PATH CFLAGS CXXFLAGS LDFLAGS
     echo.
     echo.export CARGO_HOME="/opt/cargo"
-    echo.[[ ${MABS_ORIGINAL_RUSTFLAGS+x} ]] ^|^| MABS_ORIGINAL_RUSTFLAGS="$RUSTFLAGS"
-    echo.export RUSTFLAGS="$MABS_ORIGINAL_RUSTFLAGS"
-    if "%1"=="64" echo.export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C target-cpu=%targetPlatform%"
-    echo.[[ $RUSTFLAGS ]] ^|^| unset RUSTFLAGS
     echo.if [[ -z "$CCACHE_DIR" ]]; then
     echo.    export CCACHE_DIR="${LOCALBUILDDIR}/cache"
     echo.fi

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -143,7 +143,7 @@ set mpv_options_basic="-Dlua=luajit"
 set mpv_options_full=dvdnav cdda #egl-angle #html-build ^
 #pdf-build openal sdl2-gamepad sdl2-audio sdl2-video
 
-set iniOptions=arch license2 vpx2 x2643 x2652 other265 flac fdkaac mediainfo ^
+set iniOptions=arch targetPlatform license2 vpx2 x2643 x2652 other265 flac fdkaac mediainfo ^
 soxB ffmpegB2 ffmpegUpdate ffmpegChoice ffmpegKeepLegacyOpts mp4box rtmpdump mplayer2 mpv ^
 cores deleteSource strip pack logging bmx standalone updateSuite av1an aom faac exhale ffmbc ^
 curl cyanrip2 rav1e ripgrep dav1d libavif libheif vvc uvg266 jq dssim gifski avs2 dovitool ^
@@ -200,6 +200,36 @@ if %buildEnv%==2 set "build32=yes" && set "build64=no"
 if %buildEnv%==3 set "build32=no" && set "build64=yes"
 if %buildEnv% GTR 3 GOTO selectSystem
 if %deleteINI%==1 echo.arch=^%buildEnv%>>%ini%
+
+:targetPlatform
+if [0]==[%targetPlatformINI%] (
+    if %build64%==yes (
+        echo -------------------------------------------------------------------------------
+        echo -------------------------------------------------------------------------------
+        echo.
+        echo. Choose CPU requirement for 64-bit binaries:
+        echo. 1 = x86-64, baseline x64 [maximum compatibility]
+        echo. 2 = x86-64-v2, SSE4.2/POPCNT-capable CPUs
+        echo. 3 = x86-64-v3, AVX/AVX2-capable CPUs [recommended]
+        echo. 4 = x86-64-v4, AVX-512-capable CPUs, limited compatibility
+        echo. 5 = native, optimize for this CPU, not portable
+        echo.
+        echo. For "both", this only affects 64-bit builds; 32-bit stays generic.
+        echo.
+        echo -------------------------------------------------------------------------------
+        echo -------------------------------------------------------------------------------
+        set /P buildTargetPlatform="64-bit CPU target: "
+    ) else set "buildTargetPlatform=1"
+) else set buildTargetPlatform=%targetPlatformINI%
+
+if "%buildTargetPlatform%"=="" GOTO targetPlatform
+if %buildTargetPlatform%==1 set "targetPlatform=x86-64"
+if %buildTargetPlatform%==2 set "targetPlatform=x86-64-v2"
+if %buildTargetPlatform%==3 set "targetPlatform=x86-64-v3"
+if %buildTargetPlatform%==4 set "targetPlatform=x86-64-v4"
+if %buildTargetPlatform%==5 set "targetPlatform=native"
+if %buildTargetPlatform% GTR 5 GOTO targetPlatform
+if %deleteINI%==1 echo.targetPlatform=^%buildTargetPlatform%>>%ini%
 
 :ffmpeglicense
 if [0]==[%license2INI%] (
@@ -2053,6 +2083,8 @@ if not exist %instdir%\%1\share (
 goto :EOF
 
 :writeProfile
+set "profileMarchFlag= -march=%targetPlatform%"
+if %1==32 set "profileMarchFlag="
 (
     echo.#!/usr/bin/bash
     if %1==32 (
@@ -2098,7 +2130,7 @@ goto :EOF
     echo.PKG_CONFIG_PATH="${LOCALDESTDIR}/lib/pkgconfig:${MINGW_PREFIX}/lib/pkgconfig"
     echo.
     echo.CFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong" # security related flags
-    echo.CFLAGS+=" -mtune=generic -O2 -pipe" # performance related flags
+    echo.CFLAGS+=" -mtune=generic -O2 -pipe%profileMarchFlag%" # performance related flags
     echo.CFLAGS+=" -D__USE_MINGW_ANSI_STDIO=1" # mingw-w64 specific flags for c99 printf
     echo.CXXFLAGS="${CFLAGS}" # copy CFLAGS to CXXFLAGS
     echo.LDFLAGS="${CFLAGS} -static-libgcc" # copy CFLAGS to LDFLAGS
@@ -2119,6 +2151,10 @@ goto :EOF
     echo.export DXSDK_DIR ACLOCAL_PATH PKG_CONFIG PKG_CONFIG_PATH CFLAGS CXXFLAGS LDFLAGS
     echo.
     echo.export CARGO_HOME="/opt/cargo"
+    echo.[[ ${MABS_ORIGINAL_RUSTFLAGS+x} ]] ^|^| MABS_ORIGINAL_RUSTFLAGS="$RUSTFLAGS"
+    echo.export RUSTFLAGS="$MABS_ORIGINAL_RUSTFLAGS"
+    if "%1"=="64" echo.export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C target-cpu=%targetPlatform%"
+    echo.[[ $RUSTFLAGS ]] ^|^| unset RUSTFLAGS
     echo.if [[ -z "$CCACHE_DIR" ]]; then
     echo.    export CCACHE_DIR="${LOCALBUILDDIR}/cache"
     echo.fi


### PR DESCRIPTION
## Summary

This PR ~adds configurable CPU targeting for 64-bit builds and~ expands support for several optional FFmpeg dependencies:

- ~Add selectable x86-64 CPU targets~.
- Restore static libssh support.
- Add an optional 10-bit davs2 build.
- Add Fraunhofer libmpeghdec support.

## Changes

### ~Configurable CPU target~ (Removed)

~Add a `targetPlatform` option for selecting `x86-64`, `x86-64-v2`,
`x86-64-v3`, `x86-64-v4`, or `native`.~

~This allows users to balance binary compatibility and performance instead
of forcing every 64-bit build to use the same generic CPU baseline. Newer
targets let the compiler use instruction sets available on modern CPUs,
which may improve performance in compute-intensive multimedia workloads.~

~The selected target is applied consistently to C/C++ and Rust code.
For combined 32/64-bit builds, the 32-bit output remains generic to preserve
compatibility.~

### Restore libssh support

Re-enable FFmpeg's `libssh` integration using the MinGW-w64 package.

The generated pkg-config metadata is supplemented with the static dependencies required by libssh, including OpenSSL, zlib, Winsock, IP Helper API, and pthread. 

### Optional 10-bit davs2

Add an opt-in 10-bit davs2 decoder using the unofficial
`saindriches/davs2` fork. The official `pkuvcl/davs2` repository currently
remains the source for the existing 8-bit option and is not replaced.

The fork is explicitly presented as unofficial because it is maintained
outside the upstream davs2 project. Users should therefore be aware that
its maintenance status, compatibility, and review process may differ from
the official implementation.

### Add libmpeghdec(Fixes #3021)

Add build support for Fraunhofer IIS's MPEG-H decoder:

- Build and install the static decoder library.
- Enable the decoder and UI manager executables for standalone builds.
- Add the required `MPEGHDEC_STATIC` pkg-config flag.
- ~Apply a small MinGW compatibility adjustment to avoid duplicate `SHORT` overloads under the LLP64 data model.(upstream issue https://github.com/Fraunhofer-IIS/mpeghdec/issues/17)~