### PR TITLE
gnutls: update to 3.8.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For information about the compiler environment see the wiki, there you also have
                 - needs non-GPL license
             - mbedtls (mingw-w64)
                 - preferred to gnutls if GPLv3 license is chosen
-            - gnutls (3.8.9)
+            - gnutls (3.8.13)
         - libass (git)
             - by default with DirectWrite backend
             - if --enable-fontconfig, fontconfig backend included

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -547,8 +547,8 @@ if enabled_any gnutls librtmp || [[ $rtmpdump = y || $curl = gnutls ]]; then
     grep_and_sed '__declspec(__dllimport__)' "$MINGW_PREFIX"/include/gmp.h \
         's|__declspec\(__dllimport__\)||g' "$MINGW_PREFIX"/include/gmp.h
     _check=(libgnutls.{,l}a gnutls.pc)
-    _gnutls_ver=3.8.9
-    _gnutls_hash=69e113d802d1670c4d5ac1b99040b1f2d5c7c05daec5003813c049b5184820ed
+    _gnutls_ver=3.8.13
+    _gnutls_hash=ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e
     if do_pkgConfig "gnutls = $_gnutls_ver" && do_wget -h $_gnutls_hash \
         "https://www.gnupg.org/ftp/gcrypt/gnutls/v${_gnutls_ver%.*}/gnutls-${_gnutls_ver}.tar.xz"; then
         do_uninstall include/gnutls "${_check[@]}"


### PR DESCRIPTION
Fixes #3146 and #3148

On a related note, the fork of rtmpdump also does not compile for the same reason the older version of gnutls didn't compile, that being the upgrade to nettle 4.0 a week ago. msys2's rtmpdump package got [a patch](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-rtmpdump/0014-nettle-4.patch) to address this, maybe you could apply something similar to your rtmpdump fork @1480c1?