### PR TITLE
ffmpeg: remove auto-enable libglslang

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2393,7 +2393,7 @@ fi
 _check=(lib{glslang,OSDependent}.a
         libSPIRV{,-Tools{,-opt,-link,-reduce}}.a glslang/SPIRV/GlslangToSpv.h)
 if { [[ $mpv != n ]] ||
-     { [[ $ffmpeg != no ]] && enabled_any libplacebo libglslang libshaderc vulkan; } } &&
+     { [[ $ffmpeg != no ]] && enabled_any libplacebo libglslang libshaderc; } } &&
     do_vcs "$SOURCE_REPO_GLSLANG"; then
     do_uninstall libHLSL.a "${_check[@]}"
     sed -i "s|command_output(\['git', 'clone',|command_output(\['git', 'clone', '--filter=tree:0',|" ./update_glslang_sources.py
@@ -2597,7 +2597,6 @@ if [[ $ffmpeg != no ]]; then
                 's|__declspec\(__dllimport__\)||g' "$MINGW_PREFIX"/include/gmp.h
         fi
 
-        enabled vulkan && ! enabled_any libshaderc libglslang && do_addOption --enable-libglslang
         enabled_all libshaderc libglslang && do_removeOption --enable-libglslang
         enabled libshaderc && sed -ri 's/(require_pkg_config spirv_library "shaderc) >/\1_combined >/' configure
 


### PR DESCRIPTION
Fixes #3150
leaves some remnants of the logic for non-latest FFmpeg build

<!--
Description

(Optional) Fixes #[issueNumber]
--->
