### PR TITLE
ffmpeg: finish compile-time SPIR-V migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ For information about the compiler environment see the wiki, there you also have
         - libdavs2 (git)
         - libflite (git)
         - libfribidi (git)
-        - libglslang (git)
         - libgme (git)
         - libilbc (git)
         - libjxl (git)

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2416,15 +2416,14 @@ if { [[ $mpv != n ]] ||
     do_vcs "$SOURCE_REPO_SPIRV_CROSS"; then
     do_uninstall include/spirv_cross "${_check[@]}" spirv-cross-c-shared.pc libspirv-cross-c-shared.a
     do_patch "https://raw.githubusercontent.com/m-ab-s/mabs-patches/master/SPIRV-Cross/0001-add-a-basic-Meson-build-system-for-use-as-a-subproje.patch" am
-    sed -i 's/0.13.0/0.48.0/' meson.build
     do_mesoninstall
     do_checkIfExist
 fi
 
-_check=(lib{glslang,OSDependent}.a
+_check=(bin/glslangValidator.exe lib{glslang,OSDependent}.a
         libSPIRV{,-Tools{,-opt,-link,-reduce}}.a glslang/SPIRV/GlslangToSpv.h)
 if { [[ $mpv != n ]] ||
-     { [[ $ffmpeg != no ]] && enabled_any libplacebo libglslang libshaderc; } } &&
+     { [[ $ffmpeg != no ]] && enabled_any vulkan libplacebo; } } &&
     do_vcs "$SOURCE_REPO_GLSLANG"; then
     do_uninstall libHLSL.a "${_check[@]}"
     sed -i "s|command_output(\['git', 'clone',|command_output(\['git', 'clone', '--filter=tree:0',|" ./update_glslang_sources.py
@@ -2435,7 +2434,7 @@ fi
 
 _check=(shaderc/shaderc.h libshaderc_combined.a)
 if { [[ $mpv != n ]] ||
-     { [[ $ffmpeg != no ]] && enabled_any libplacebo libshaderc; } } ||
+     { [[ $ffmpeg != no ]] && enabled libplacebo; } } ||
      ! mpv_disabled shaderc &&
     do_vcs "$SOURCE_REPO_SHADERC"; then
     do_patch "https://raw.githubusercontent.com/m-ab-s/mabs-patches/master/shaderc/0001-third_party-set-INSTALL-variables-as-cache.patch" am
@@ -2627,9 +2626,6 @@ if [[ $ffmpeg != no ]]; then
             grep_and_sed '__declspec(__dllimport__)' "$MINGW_PREFIX"/include/gmp.h \
                 's|__declspec\(__dllimport__\)||g' "$MINGW_PREFIX"/include/gmp.h
         fi
-
-        enabled_all libshaderc libglslang && do_removeOption --enable-libglslang
-        enabled libshaderc && sed -ri 's/(require_pkg_config spirv_library "shaderc) >/\1_combined >/' configure
 
         _patches=$(git rev-list $ff_base_commit.. --count)
         if [[ $_patches -gt 0 ]]; then

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -104,7 +104,6 @@ SOURCE_REPO_SOX=https://git.code.sf.net/p/sox/code
 SOURCE_REPO_SPEEX=https://github.com/xiph/speex.git
 SOURCE_REPO_SPIRV_CROSS=https://github.com/KhronosGroup/SPIRV-Cross.git
 SOURCE_REPO_SPIRV_HEADERS=https://github.com/KhronosGroup/SPIRV-Headers.git
-SOURCE_REPO_SPIRV_TOOLS=https://github.com/KhronosGroup/SPIRV-Tools.git
 SOURCE_REPO_SRT=https://github.com/Haivision/srt.git
 SOURCE_REPO_SVTAV1=https://gitlab.com/AOMediaCodec/SVT-AV1.git
 SOURCE_REPO_SVTHEVC=https://github.com/OpenVisualCloud/SVT-HEVC.git

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -929,9 +929,9 @@ do_getFFmpegConfig() {
     fi
 
     if [[ $ffmpegKeepLegacyOpts == n ]]; then
-        enabled_any lib{vo-aacenc,aacplus,utvideo,dcadec,faac,ebur128,ndi_newtek,ndi-newtek,npp,wavpack} netcdf &&
-            do_removeOption "--enable-(lib(vo-aacenc|aacplus|utvideo|dcadec|faac|ebur128|ndi_newtek|ndi-newtek|npp|wavpack)|netcdf)" &&
-            sed -ri 's;--enable-(lib(vo-aacenc|aacplus|utvideo|dcadec|faac|ebur128|ndi_newtek|ndi-newtek|npp|wavpack)|netcdf);;g' \
+        enabled_any lib{vo-aacenc,aacplus,utvideo,dcadec,faac,ebur128,glslang,ndi_newtek,ndi-newtek,npp,shaderc,wavpack} netcdf &&
+            do_removeOption "--enable-(lib(vo-aacenc|aacplus|utvideo|dcadec|faac|ebur128|glslang|ndi_newtek|ndi-newtek|npp|shaderc|wavpack)|netcdf)" &&
+            sed -ri 's;--enable-(lib(vo-aacenc|aacplus|utvideo|dcadec|faac|ebur128|glslang|ndi_newtek|ndi-newtek|npp|shaderc|wavpack)|netcdf);;g' \
                 "$LOCALBUILDDIR/ffmpeg_options.txt"
     fi
 }

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -125,7 +125,7 @@ set ffmpeg_options_full=chromaprint decklink frei0r libaribb24 libbs2b libcaca ^
 libcdio libflite libfribidi libgme libilbc libsvthevc ^
 libsvtvp9 libkvazaar libmodplug librist librtmp librubberband #libssh ^
 libtesseract libxavs libzmq libzvbi openal libcodec2 ladspa #vapoursynth #liblensfun ^
-libglslang vulkan libdavs2 libxavs2 libuavs3d libplacebo libjxl libvvenc libvvdec liblc3 audiotoolbox ^
+vulkan libdavs2 libxavs2 libuavs3d libplacebo libjxl libvvenc libvvdec liblc3 audiotoolbox ^
 libsvtjpegxs
 
 :: options also available with the suite that add shared dependencies


### PR DESCRIPTION
Follow up on #3151 , which stopped auto-enabling libglslang while retaining legacy FFmpeg logic.

- remove obsolete libglslang/libshaderc options and configure workarounds
- use glslangValidator as FFmpeg's build-time SPIR-V compiler
- keep shaderc usage limited to mpv and libplacebo
- remove stale SPIRV-Cross version rewriting and the unused SPIRV-Tools source entry

The following mabs-patches PRs need to be merged first:

- m-ab-s/mabs-patches#14 updates the Vulkan-Loader 0005 patch for current upstream.
- m-ab-s/mabs-patches#15 fixes SPIRV-Cross version handling in its Meson patch, replacing the hard-coded version rewrite removed here.