### PR TITLE
bat: disable pacman progress bars in CI

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1775,6 +1775,7 @@ if not exist %instdir%\mintty.lnk (
     call :runBash firstrun.log exit
 
     sed -i "s/#Color/Color/;s/^^IgnorePkg.*/#&/" %instdir%\msys64\etc\pacman.conf
+    if defined CI sed -i "s/^^#NoProgressBar/NoProgressBar/" %instdir%\msys64\etc\pacman.conf
 
     echo.-------------------------------------------------------------------------------
     echo.first update


### PR DESCRIPTION
CI runs use a pseudo-terminal, causing pacman progress updates to expand into many log lines.

Enable `NoProgressBar` when `CI` is defined while preserving normal interactive output.