### PR TITLE
bat: fix sed input

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1774,8 +1774,8 @@ if not exist %instdir%\mintty.lnk (
     echo -------------------------------------------------------------------------------
     call :runBash firstrun.log exit
 
-    sed -i "s/#Color/Color/;s/^^IgnorePkg.*/#&/" %instdir%\msys64\etc\pacman.conf
-    if defined CI sed -i "s/^^#NoProgressBar/NoProgressBar/" %instdir%\msys64\etc\pacman.conf
+    sed -i "s/#Color/Color/;s/^IgnorePkg.*/#&/" %instdir%\msys64\etc\pacman.conf
+    if defined CI sed -i "s/#NoProgressBar/NoProgressBar/" %instdir%\msys64\etc\pacman.conf
 
     echo.-------------------------------------------------------------------------------
     echo.first update


### PR DESCRIPTION
The sed expression is already inside double quotes, so `cmd.exe` passes `^` through without requiring caret escaping.

Using `^^` therefore sends two carets to sed: the first is the start-of-line anchor, while the second is treated literally. This matches `^IgnorePkg` rather than `IgnorePkg`.

Use a single `^` to correctly anchor the pattern at the start of the line.