### PR TITLE
dlfcn: remove redundant source build

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1810,13 +1810,6 @@ if [[ $ffmpeg != no ]] && enabled libzvbi &&
 fi
 
 if [[ $ffmpeg != no ]] && enabled_any frei0r ladspa; then
-    _check=(libdl.a dlfcn.h)
-    if do_vcs "$SOURCE_REPO_DLFCN"; then
-        do_uninstall "${_check[@]}"
-        do_cmakeinstall
-        do_checkIfExist
-    fi
-
     _check=(frei0r.{h,pc})
     if do_vcs "$SOURCE_REPO_FREI0R"; then
         do_uninstall lib/frei0r-1 "${_check[@]}"

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1814,7 +1814,7 @@ if [[ $ffmpeg != no ]] && enabled_any frei0r ladspa; then
     if do_vcs "$SOURCE_REPO_FREI0R"; then
         do_uninstall lib/frei0r-1 "${_check[@]}"
         do_pacman_install gavl
-        do_cmakeinstall -DWITHOUT_OPENCV=on -DWITHOUT_CAIRO=on
+        do_cmakeinstall -DBUILD_TESTING=OFF -DWITHOUT_OPENCV=on -DWITHOUT_CAIRO=on
         do_checkIfExist
     fi
 fi

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -14,7 +14,6 @@ SOURCE_REPO_DAV1D=https://code.videolan.org/videolan/dav1d.git
 SOURCE_REPO_DAVS=https://github.com/pkuvcl/davs2.git
 SOURCE_REPO_DAVS10bit=https://github.com/saindriches/davs2.git
 SOURCE_REPO_DECKLINK=https://gitlab.com/m-ab-s/decklink-headers.git
-SOURCE_REPO_DLFCN=https://github.com/dlfcn-win32/dlfcn-win32.git
 SOURCE_REPO_DOVI_TOOL=https://github.com/quietvoid/dovi_tool.git
 SOURCE_REPO_DSSIM=https://github.com/kornelski/dssim.git
 SOURCE_REPO_EXHALE=https://gitlab.com/ecodis/exhale.git


### PR DESCRIPTION
Use `libdl.a` from the MinGW `dlfcn` package already installed by the suite instead of fetching and compiling `dlfcn-win32` again.

Disable unused frei0r tests to avoid their shared dlfcn target.