### PR TITLE
libaribcaption: add FFmpeg build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For information about the compiler environment see the wiki, there you also have
         - frei0r (git)
         - ladspa (mingw-w64)
         - libaribb24 (git)
+        - libaribcaption (git)
         - libbs2b (3.1.0)
         - libcaca (mingw-w64)
         - libcdio (mingw-w64)

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -418,6 +418,14 @@ fi
 # Probably caused by https://gitlab.gnome.org/GNOME/libxml2/-/commit/93e8bb2a402012858500b608b4146cd5c756e34d
 grep_or_sed Requires.private "$LOCALDESTDIR/lib/pkgconfig/libxml-2.0.pc" 's/Requires:/Requires.private:/'
 
+_check=(aribcaption/aribcaption.h libaribcaption.{a,pc})
+if [[ $ffmpeg != no ]] && enabled libaribcaption &&
+    do_vcs "$SOURCE_REPO_ARIBCAPTION"; then
+    do_uninstall include/aribcaption lib/cmake/aribcaption "${_check[@]}"
+    do_cmakeinstall -DARIBCC_SHARED_LIBRARY=OFF -DARIBCC_BUILD_TESTS=OFF
+    do_checkIfExist
+fi
+
 if [[ $ffmpeg != no ]] && enabled libaribb24; then
     _deps=("$zlib_dir"/lib/libz.a)
     _check=(libpng.{pc,{,l}a} libpng16.{pc,{,l}a} libpng16/png.h)

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -4,6 +4,7 @@
 SOURCE_REPO_AMF=https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git
 SOURCE_REPO_ANGLE=https://chromium.googlesource.com/angle/angle
 SOURCE_REPO_ARRIB24=https://github.com/nkoriyama/aribb24.git
+SOURCE_REPO_ARIBCAPTION=https://github.com/xqq/libaribcaption.git
 SOURCE_REPO_AUDIOTOOLBOX=https://github.com/cynagenautes/AudioToolboxWrapper.git
 SOURCE_REPO_AV1AN=https://github.com/rust-av/Av1an.git
 SOURCE_REPO_AVISYNTH=https://github.com/AviSynth/AviSynthPlus.git

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -121,7 +121,7 @@ libwebp libxml2 libzimg libshine openssl libtls avisynth #mbedtls libxvid ^
 libopenmpt version3 librav1e libsrt libgsm libvmaf libsvtav1
 
 :: options also available with the suite
-set ffmpeg_options_full=chromaprint decklink frei0r libaribb24 libbs2b libcaca ^
+set ffmpeg_options_full=chromaprint decklink frei0r libaribb24 libaribcaption libbs2b libcaca ^
 libcdio libflite libfribidi libgme libilbc libsvthevc ^
 libsvtvp9 libkvazaar libmodplug librist librtmp librubberband #libssh ^
 libtesseract libxavs libzmq libzvbi openal libcodec2 ladspa #vapoursynth #liblensfun ^


### PR DESCRIPTION
Add optional libaribcaption support and enable it in the Full FFmpeg preset.

Compared with the older libaribb24 implementation, libaribcaption is actively maintained and provides more complete ARIB STD-B24 decoding and rendering, including Profile A/C and multiple ISDB caption variants. It is already supported by FFmpeg and widely adopted by downstream builds such as BtbN/FFmpeg-Builds and Gyan.dev .

This adds the source definition, static CMake build, FFmpeg option, and documentation.