### PR TITLE
helper: skip user prompts in CI

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1826,6 +1826,10 @@ do_pacman_remove() (
 )
 
 do_prompt() {
+    if [[ -n ${CI:-} ]]; then
+        ret=
+        return 0
+    fi
     # from http://superuser.com/a/608509
     while read -r -s -e -t 0.1; do :; done
     read -r -p "$1" ret


### PR DESCRIPTION
`do_prompt` may wait indefinitely in CI environments where no interactive user input is available.

Skip the prompt when the `CI` environment variable is non-empty and clear `ret` so existing callers use their default behavior. 