### PR TITLE
helper: refetch partial clones for 3-way patching

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1277,6 +1277,10 @@ do_patch() {
 
     if [[ -f $patchName ]]; then
         if $am; then
+            if ! git apply -3 --check --ignore-space-change --ignore-whitespace "$patchName" > /dev/null 2>&1 &&
+                git config --get remote.origin.partialclonefilter > /dev/null 2>&1; then
+                git fetch -q --refetch --no-filter
+            fi
             git apply -3 --check --ignore-space-change --ignore-whitespace "$patchName" > /dev/null 2>&1 &&
                 git am -q -3 --ignore-whitespace --no-gpg-sign "$patchName" > /dev/null 2>&1 &&
                 return 0


### PR DESCRIPTION
`vcs_clone` uses `--filter=tree:0`, which omits historical blobs when supported by the remote.

This can break stale patches relying on `git am -3`: patches usually contain abbreviated preimage object IDs, so Git cannot lazy-fetch the missing base blob. On failure, refetch the partial clone without filtering and retry. Normal patches and full clones keep the existing fast path.

Patches to FFmpeg exposed this issue after I changed its source from the official repository to the GitHub mirror due to connectivity problems. FFmpeg's official repository server ignored the filter, while GitHub honors it. Consequently, the SVT-VP9 patch could no longer perform its three-way merge.

I have also submitted a separate PR rebasing the SVT-VP9 patch https://github.com/1480c1/SVT-VP9/pull/1 . Please review and merge it alongside this fix.