### PR TITLE
feat: add support for libqrencode and libquirc

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -783,6 +783,24 @@ if [[ $jpegxl = y ]] || { [[ $ffmpeg != no ]] && enabled libjxl; }; then
     fi
 fi
 
+_check=(libqrencode.a libqrencode.pc qrencode.h)
+if [[ $ffmpeg != no ]] && enabled libqrencode &&
+    do_vcs "$SOURCE_REPO_LIBQRENCODE"; then
+    do_uninstall "${_check[@]}"
+    do_cmakeinstall -DWITH_TOOLS=OFF -DWITH_TESTS=OFF -DWITHOUT_PNG=ON
+    do_checkIfExist
+fi
+
+_check=(libquirc.a quirc.h)
+if [[ $ffmpeg != no ]] && enabled libquirc &&
+    do_vcs "$SOURCE_REPO_QUIRC"; then
+    do_uninstall "${_check[@]}"
+    do_make libquirc.a CFLAGS="$CFLAGS -fPIC" SDL_CFLAGS=
+    do_install libquirc.a
+    do_install lib/quirc.h quirc.h
+    do_checkIfExist
+fi
+
 if files_exist bin-video/OpenCL.dll; then
     opencldll=$LOCALDESTDIR/bin-video/OpenCL.dll
 else

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -66,6 +66,7 @@ SOURCE_REPO_LIBOGG=https://github.com/xiph/ogg.git
 SOURCE_REPO_LIBOPENMPT=https://github.com/OpenMPT/openmpt.git#branch=OpenMPT-1.30
 SOURCE_REPO_LIBOPUSENC=https://github.com/xiph/libopusenc.git
 SOURCE_REPO_LIBPLACEBO=https://code.videolan.org/videolan/libplacebo.git
+SOURCE_REPO_LIBQRENCODE=https://github.com/fukuchi/libqrencode.git
 SOURCE_REPO_LIBPNG=https://github.com/pnggroup/libpng.git#branch=libpng16
 SOURCE_REPO_LIBRAV1E=https://github.com/xiph/rav1e.git
 SOURCE_REPO_LIBRESSL=https://github.com/libressl-portable/portable.git#tag=LATEST
@@ -95,6 +96,7 @@ SOURCE_REPO_OPENCLHEADERS=https://github.com/KhronosGroup/OpenCL-Headers.git
 SOURCE_REPO_OPUS=https://github.com/xiph/opus.git
 SOURCE_REPO_OPUSEXE=https://github.com/xiph/opus-tools.git
 SOURCE_REPO_OPUSFILE=https://github.com/xiph/opusfile.git
+SOURCE_REPO_QUIRC=https://github.com/dlbeer/quirc.git
 SOURCE_REPO_RIPGREP=https://github.com/BurntSushi/ripgrep.git
 SOURCE_REPO_RUBBERBAND=https://github.com/m-ab-s/rubberband.git
 SOURCE_REPO_SDL2=https://github.com/libsdl-org/SDL.git#SDL2


### PR DESCRIPTION
This PR adds build support for two QR-code libraries used by FFmpeg:

- [quirc](https://github.com/dlbeer/quirc): a lightweight QR-code recognition and decoding library, used by FFmpeg's `quirc` filter.
- [libqrencode](https://github.com/fukuchi/libqrencode): a QR-code generation library, used by FFmpeg's `qrencode` and `qrencodesrc` filters.

Both libraries are already adopted by Gyan's FFmpeg builds. 