### PR TITLE
Oapv fix and minor cleanup

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -438,7 +438,7 @@ if [[ $ffmpeg != no ]] && enabled libaribb24; then
 
     _deps=(libpng.{pc,a} libpng16.{pc,a})
     _check=(aribb24.pc libaribb24.{,l}a)
-    if do_vcs "$SOURCE_REPO_ARRIB24"; then
+    if do_vcs "$SOURCE_REPO_ARIBB24"; then
         do_patch "https://raw.githubusercontent.com/BtbN/FFmpeg-Builds/master/patches/aribb24/12.patch"
         do_patch "https://raw.githubusercontent.com/BtbN/FFmpeg-Builds/master/patches/aribb24/13.patch"
         do_patch "https://raw.githubusercontent.com/BtbN/FFmpeg-Builds/master/patches/aribb24/17.patch"

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -3,7 +3,7 @@
 # Dependency References
 SOURCE_REPO_AMF=https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git
 SOURCE_REPO_ANGLE=https://chromium.googlesource.com/angle/angle
-SOURCE_REPO_ARRIB24=https://github.com/nkoriyama/aribb24.git
+SOURCE_REPO_ARIBB24=https://github.com/nkoriyama/aribb24.git
 SOURCE_REPO_ARIBCAPTION=https://github.com/xqq/libaribcaption.git
 SOURCE_REPO_AUDIOTOOLBOX=https://github.com/cynagenautes/AudioToolboxWrapper.git
 SOURCE_REPO_AV1AN=https://github.com/rust-av/Av1an.git
@@ -52,6 +52,7 @@ SOURCE_REPO_LIBDE265=https://github.com/strukturag/libde265.git
 SOURCE_REPO_LIBDVDNAV=https://code.videolan.org/videolan/libdvdnav.git
 SOURCE_REPO_LIBDVDREAD=https://code.videolan.org/videolan/libdvdread.git
 SOURCE_REPO_LIBGLUT=https://github.com/dcnieho/FreeGLUT.git
+SOURCE_REPO_LIBGME=https://github.com/libgme/game-music-emu.git
 SOURCE_REPO_LIBHEIF=https://github.com/strukturag/libheif.git
 SOURCE_REPO_LIBILBC=https://github.com/TimothyGu/libilbc.git
 SOURCE_REPO_LIBJXL=https://github.com/libjxl/libjxl.git
@@ -136,4 +137,3 @@ SOURCE_REPO_ZLIBCLOUDFLARE=https://github.com/cloudflare/zlib.git
 SOURCE_REPO_ZLIBNG=https://github.com/zlib-ng/zlib-ng.git
 SOURCE_REPO_ZLIBRS=https://github.com/trifectatechfoundation/zlib-rs.git
 SOURCE_REPO_ZVBI=https://github.com/zapping-vbi/zvbi.git
-SOURCE_REPO_LIBGME=https://github.com/libgme/game-music-emu.git

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -91,7 +91,7 @@ SOURCE_REPO_MPV=https://github.com/mpv-player/mpv.git
 SOURCE_REPO_MUJS=https://codeberg.org/ccxvii/mujs.git
 SOURCE_REPO_NEON=https://github.com/notroj/neon.git
 SOURCE_REPO_OPENAL=https://github.com/kcat/openal-soft.git#tag=latest
-SOURCE_REPO_OPENAPV=https://github.com/AcademySoftwareFoundation/openapv.git
+SOURCE_REPO_OPENAPV=https://github.com/AcademySoftwareFoundation/openapv.git#commit=a5312e4fa405057ff0be2c370283fabfe588c1f4
 SOURCE_REPO_OPENCLHEADERS=https://github.com/KhronosGroup/OpenCL-Headers.git
 SOURCE_REPO_OPUS=https://github.com/xiph/opus.git
 SOURCE_REPO_OPUSEXE=https://github.com/xiph/opus-tools.git

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -121,15 +121,6 @@ test_newer() {
     return 1
 }
 
-# vcs_get_current_type /build/myrepo
-vcs_get_current_type() {
-    git -C "${1:-$PWD}" rev-parse --is-inside-work-tree > /dev/null 2>&1 &&
-        echo "git" &&
-        return 0
-    echo "unknown"
-    return 1
-}
-
 # check_valid_vcs /build/ffmpeg-git
 check_valid_vcs() {
     [[ -d ${1:-$PWD}/.git ]] &&
@@ -332,64 +323,6 @@ do_vcs() {
         do_print_status prefix "$bold├$reset " "Found recompile flag" "$orange" "Recompiling"
     fi
     extra_script post vcs
-    return 0
-}
-
-# get source from VCS to a local subfolder
-# example:
-#   do_vcs_local "url#branch|revision|tag|commit=NAME" "subfolder"
-do_vcs_local() {
-    local vcsURL=${1#*::} vcsFolder=$2 vcsCheck=("${_check[@]}")
-    local vcsBranch=${vcsURL#*#} ref=origin/HEAD
-    local deps=("${_deps[@]}") && unset _deps
-    [[ $vcsBranch == "$vcsURL" ]] && unset vcsBranch
-    vcsURL=${vcsURL%#*}
-    : "${vcsFolder:=$(basename "$vcsURL" .git)}"
-
-    if [[ -n $vcsBranch ]]; then
-        ref=${vcsBranch##*=}
-        [[ ${vcsBranch%%=*}/$ref == branch/${ref%/*} ]] && ref=origin/$ref
-    fi
-
-    rm -f "$vcsFolder/custom_updated"
-
-    # try to see if we can "resolve" the currently provided ref, minus the origin/ part,
-    # if so, set ref to the ref on the origin, this might make it harder for people who
-    # want use multiple remotes other than origin. Converts ref=develop to ref=origin/develop
-    # ignore those that use the special tags/branches
-    case $ref in
-    LATEST | GREATEST | *\**) ;;
-    *) git ls-remote --exit-code "$vcsURL" "${ref#origin/}" > /dev/null 2>&1 && ref=origin/${ref#origin/} ;;
-    esac
-
-    if ! check_valid_vcs "$vcsFolder"; then
-        rm -rf "$vcsFolder"
-        rm -rf "$vcsFolder-git"
-        do_print_progress "  Running git clone for $vcsFolder"
-        if ! do_mabs_clone "$vcsURL" "$vcsFolder" "$ref"; then
-            echo "$vcsFolder git seems to be down"
-            echo "Try again later or <Enter> to continue"
-            do_prompt "if you're sure nothing depends on it."
-            # unset_extra_script
-            return 1
-        fi
-        mv "$vcsFolder-git" "$vcsFolder"
-        touch "$vcsFolder"/recently_{updated,checked}
-    fi
-
-    cd_safe "$vcsFolder"
-
-    vcs_set_url "$vcsURL"
-    log -q git.fetch vcs_fetch
-    oldHead=$(vcs_get_merge_base "$ref")
-    do_print_progress "  Running git update for $vcsFolder"
-    log -q git.reset vcs_reset "$ref"
-    newHead=$(vcs_get_current_head "$PWD")
-
-    vcs_clean
-
-    cd ..
-
     return 0
 }
 
@@ -1297,14 +1230,6 @@ do_patch() {
             '\tPatch not found anywhere. Continuing without patching.'
     fi
     return 1
-}
-
-do_custom_patches() {
-    local patch
-    for patch in "$@"; do
-        [[ ${patch##*.} == "patch" ]] && do_patch "$patch" am
-        [[ ${patch##*.} == "diff" ]] && do_patch "$patch"
-    done
 }
 
 do_cmake() {
@@ -2700,17 +2625,4 @@ _post_install() {
 EOF
     printf '%s' "$script_file" > "${LOCALBUILDDIR}/${extraName}_extra.sh"
     echo "Created skeleton file ${LOCALBUILDDIR}/${extraName}_extra.sh"
-}
-
-# if you absolutely need to remove some of these,
-# add a "-e '!<hardcoded rule>'"  option
-# ex: "-e '!/recently_updated'"
-safe_git_clean() {
-    git clean -xfd \
-        -e "/build_successful*" \
-        -e "/recently_updated" \
-        -e '/custom_updated' \
-        -e '/do_not_build' \
-        -e '**/ab-suite.*.log' \
-        "${@}"
 }


### PR DESCRIPTION
## Openapv ##
Openapv has been done some breaking changes recently, which brakes compatibility with ffmpeg. Therefore, when compiling ffmpeg with `--enable-liboapv`, error occurs:

```
CC	libavcodec/liboapvenc.o
src/libavcodec/liboapvenc.c: In function 'liboapve_init':
src/libavcodec/liboapvenc.c:512:29: error: passing argument 1 of 'oapvm_create' from incompatible pointer type [-Wincompatible-pointer-types]
  512 |     apv->mid = oapvm_create(&ret);
      |                             ^~~~
      |                             |
      |                             int *
In file included from src/libavcodec/liboapvenc.c:27:
D:/mabs/local64/include/oapv/oapv.h:750:49: note: expected 'oapvm_cdesc_t *' {aka 'struct oapvm_cdesc *'} but argument is of type 'int *'
  750 | OAPV_EXPORT oapvm_t oapvm_create(oapvm_cdesc_t *cdesc, int *err);
      |                                  ~~~~~~~~~~~~~~~^~~~~
src/libavcodec/liboapvenc.c:512:16: error: too few arguments to function 'oapvm_create'; expected 2, have 1
  512 |     apv->mid = oapvm_create(&ret);
      |                ^~~~~~~~~~~~
D:/mabs/local64/include/oapv/oapv.h:750:21: note: declared here
  750 | OAPV_EXPORT oapvm_t oapvm_create(oapvm_cdesc_t *cdesc, int *err);
      |                     ^~~~~~~~~~~~
make: *** [/build/ffmpeg-git/ffbuild/common.mak:83: libavcodec/liboapvenc.o] Error 1
```
Temporarily downgrade lib openapv to tag `v0.3.0.0` to fix it.

## Cleanup ##
Remove four unused helper functions: `vcs_get_current_type`, `do_vcs_local`, `do_custom_patches`, `safe_git_clean`. 
Their original callers have been removed or replaced by current VCS, custom script, and cleanup logic